### PR TITLE
SSID and passphrase fix (GIT8266O-280)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ eagle.app.v6.flash.bin, downloads to flash 0x00000
 eagle.app.v6.irom0text.bin, downloads to flash 0x40000
 
 blank.bin, downloads to flash 0x7E000
+
+-
+To build using gcc, type:
+
+`make COMPILE=gcc`

--- a/app/include/ssid_config.h
+++ b/app/include/ssid_config.h
@@ -1,0 +1,24 @@
+//
+// Why this file?
+//
+// We all need to add our personal SSID/passphrase to each ESP project but we
+// do not want that information pushed to Github.
+//
+// First tell git to ignore changes to this file:
+//
+// git update-index --assume-unchanged app/include/ssid_config.h 
+//
+// Then, enter your SSID and passphrase below and it will never be committed
+// to Github.
+//
+// For reference, see
+//   https://www.kernel.org/pub/software/scm/git/docs/git-update-index.html
+//
+
+#ifndef __SSID_CONFIG_H__
+#define __SSID_CONFIG_H__
+
+#define SSID_NAME "ZTE_5560"
+#define SSID_PASS "espressif"
+
+#endif // __SSID_CONFIG_H__

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -17,6 +17,8 @@
 #include "lwip/dns.h"
 #include "lwip/netdb.h"
 
+#include "ssid_config.h"
+
 #define server_ip "192.168.101.142"
 #define server_port 9669
 
@@ -158,8 +160,8 @@ user_init(void)
 
     {
         struct station_config *config = (struct station_config *)zalloc(sizeof(struct station_config));
-        sprintf(config->ssid, "ZTE_5560");
-        sprintf(config->password, "espressif");
+        sprintf(config->ssid, SSID_NAME);
+        sprintf(config->password, SSID_PASS);
 
         /* need to sure that you are in station mode first,
          * otherwise it will be failed. */


### PR DESCRIPTION
This commit solves the problems with adding your own SSID/passphrase and not having that pushed to Github.

See app/include/ssid_config.h
