### PR TITLE
Fix arguments of UART_intr_handler_register

### DIFF
--- a/examples/driver_lib/driver/uart.c
+++ b/examples/driver_lib/driver/uart.c
@@ -421,7 +421,7 @@ uart_init_new(void)
     UART_IntrConfig(UART0, &uart_intr);
 
     UART_SetPrintPort(UART0);
-    UART_intr_handler_register(uart0_rx_intr_handler);
+    UART_intr_handler_register(uart0_rx_intr_handler, NULL);
     ETS_UART_INTR_ENABLE();
 
     /*


### PR DESCRIPTION
too few arguments to function 'UART_intr_handler_register'