### PR TITLE
Force convert function void (*)(void) to (_xt_isr) in _xt_isr_attach

### DIFF
--- a/examples/driver_lib/driver/hw_timer.c
+++ b/examples/driver_lib/driver/hw_timer.c
@@ -76,7 +76,7 @@ void hw_timer_init(uint8 req)
                       DIVDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
     }
 
-    _xt_isr_attach(ETS_FRC_TIMER1_INUM, hw_timer_isr_cb, NULL);
+    _xt_isr_attach(ETS_FRC_TIMER1_INUM, (_xt_isr)hw_timer_isr_cb, NULL);
 
     TM1_EDGE_INT_ENABLE();
     _xt_isr_unmask(1 << ETS_FRC_TIMER1_INUM);


### PR DESCRIPTION
Fix hw_timer.c:79:5: error: passing argument 2 of '_xt_isr_attach' from incompatible pointer type [-Werror]