### PR TITLE
System param area starts at 0x7c000 (not 0x7b000)

### DIFF
--- a/ld/eagle.app.v6.ld
+++ b/ld/eagle.app.v6.ld
@@ -6,7 +6,8 @@
 /* ^      ^                              ^                          ^     ^                            */
 /* |_flash.bin start(0x0000)             |_irom0text.bin start(0x20000)   |                            */
 /*        |_flash.bin end                                           |_irom0text.bin end                */
-/*                                                                        |_system param area(0x7b000) */
+/*                                                                        |_system param area(0x7c000) */
+/*                                                                         (last 4 sectors (16 kB))    */
 
 /* NOTICE: */ 
 /* 1. You can change irom0 org, but MUST make sure irom0text.bin start not overlap flash.bin end.   */
@@ -15,10 +16,10 @@
 /* 4. Space between irom0text.bin end and system param area can be used as user param area.         */
 /* 5. Make sure irom0text.bin end < 0x100000                                                        */
 /* 6. system param area:                                                                            */
-/*    1>. 512KB--->0x07b000                                                                         */
-/*    2>. 1MB----->0x0fb000                                                                         */
-/*    3>. 2MB----->0x1fb000                                                                         */
-/*    4>. 4MB----->0x3fb000                                                                         */
+/*    1>. 512KB--->0x07c000                                                                         */
+/*    2>. 1MB----->0x0fc000                                                                         */
+/*    3>. 2MB----->0x1fc000                                                                         */
+/*    4>. 4MB----->0x3fc000                                                                         */
 /* 7. Don't change any other seg.                                                                   */
 
 MEMORY

--- a/ld/eagle.app.v6.new.1024.app1.ld
+++ b/ld/eagle.app.v6.new.1024.app1.ld
@@ -5,7 +5,8 @@
 /* ^  ^                        ^     ^     ^  ^                        ^     ^                            */
 /* |_boot start(0x0000)        |     |     |_pad start(0x80000)        |     |                            */
 /*    |_user1 start(0x1000)    |_user1 end    |_user2 start(0x81000)   |_user2 end                        */
-/*                                   |_system param symmetric area(0x7b000)  |_system param area(0xfb000) */
+/*                                   |_system param symmetric area(0x7c000)  |_system param area(0xfc000) */
+/*                                                                            (last 4 sectors (16 kB))    */
 
 /* NOTICE: */ 
 /* 1. You can change irom0 len, but MUST make sure user1 end not overlap system param symmetric area. */

--- a/ld/eagle.app.v6.new.1024.app2.ld
+++ b/ld/eagle.app.v6.new.1024.app2.ld
@@ -5,7 +5,8 @@
 /* ^  ^                        ^     ^     ^  ^                        ^     ^                            */
 /* |_boot start(0x0000)        |     |     |_pad start(0x80000)        |     |                            */
 /*    |_user1 start(0x1000)    |_user1 end    |_user2 start(0x81000)   |_user2 end                        */
-/*                                   |_system param symmetric area(0x7b000)  |_system param area(0xfb000) */
+/*                                   |_system param symmetric area(0x7c000)  |_system param area(0xfc000) */
+/*                                                                            (last 4 sectors (16 kB))    */
 
 /* NOTICE: */ 
 /* 1. You can change irom0 len, but MUST make sure user2 end not overlap system param area. */

--- a/ld/eagle.app.v6.new.2048.ld
+++ b/ld/eagle.app.v6.new.2048.ld
@@ -5,7 +5,8 @@
 /* ^  ^                        ^     ^     ^  ^                        ^     ^                             */
 /* |_boot start(0x0000)        |     |     |_pad start(0x100000)       |     |                             */
 /*    |_user1 start(0x1000)    |_user1 end    |_user2 start(0x101000)  |_user2 end                         */
-/*                                   |_system param symmetric area(0xfb000)  |_system param area(0x1fb000) */
+/*                                   |_system param symmetric area(0xfc000)  |_system param area(0x1fc000) */
+/*                                                                            (last 4 sectors (16 kB))     */
 
 /* NOTICE: */ 
 /* 1. You can change irom0 len, but MUST make sure user1 end not overlap system param symmetric area. */

--- a/ld/eagle.app.v6.new.512.app1.ld
+++ b/ld/eagle.app.v6.new.512.app1.ld
@@ -5,7 +5,8 @@
 /* ^  ^                        ^     ^     ^  ^                        ^     ^                            */
 /* |_boot start(0x0000)        |     |     |_pad start(0x40000)        |     |                            */
 /*    |_user1 start(0x1000)    |_user1 end    |_user2 start(0x41000)   |_user2 end                        */
-/*                                   |_system param symmetric area(0x3b000)  |_system param area(0x7b000) */
+/*                                   |_system param symmetric area(0x3c000)  |_system param area(0x7c000) */
+/*                                                                            (last 4 sectors (16 kB))    */
 
 /* NOTICE: */ 
 /* 1. You can change irom0 len, but MUST make sure user1 end not overlap system param symmetric area. */

--- a/ld/eagle.app.v6.new.512.app2.ld
+++ b/ld/eagle.app.v6.new.512.app2.ld
@@ -5,7 +5,8 @@
 /* ^  ^                        ^     ^     ^  ^                        ^     ^                            */
 /* |_boot start(0x0000)        |     |     |_pad start(0x40000)        |     |                            */
 /*    |_user1 start(0x1000)    |_user1 end    |_user2 start(0x41000)   |_user2 end                        */
-/*                                   |_system param symmetric area(0x3b000)  |_system param area(0x7b000) */
+/*                                   |_system param symmetric area(0x3c000)  |_system param area(0x7c000) */
+/*                                                                            (last 4 sectors (16 kB))    */
 
 /* NOTICE: */ 
 /* 1. You can change irom0 len, but MUST make sure user2 end not overlap system param area. */


### PR DESCRIPTION
System param area is last 4 sectors (16 kB) of Flash memory.
=> for 512 kB it's 0x7c000
=> for 1024 kB it's 0xfc000
=> for 2048 kB it's 0x1fc000
=> for 4096 kB it's 0x3fc000