### PR TITLE
Makefile C++ flags separated from C flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ CCFLAGS += 			\
 #	-Wall			
 
 CFLAGS = $(CCFLAGS) $(DEFINES) $(EXTRA_CCFLAGS) $(INCLUDES)
+CPPFLAGS = $(CCPPFLAGS) $(DEFINES) $(EXTRA_CCFLAGS) $(INCLUDES)
 DFLAGS = $(CCFLAGS) $(DDEFINES) $(EXTRA_CCFLAGS) $(INCLUDES)
 
 
@@ -342,11 +343,11 @@ $(OBJODIR)/%.d: %.c
 	
 $(OBJODIR)/%.o: %.cpp
 	@mkdir -p $(OBJODIR);
-	$(CPP) $(if $(findstring $<,$(DSRCS)),$(DFLAGS),$(CFLAGS)) $(COPTS_$(*F)) -o $@ -c $<
+	$(CPP) $(if $(findstring $<,$(DSRCS)),$(DFLAGS),$(CPPFLAGS)) $(COPTS_$(*F)) -o $@ -c $<
 
 $(OBJODIR)/%.d: %.cpp
 	@mkdir -p $(OBJODIR);
-	@echo DEPEND: $(CPP) -M $(CFLAGS) $<
+	@echo DEPEND: $(CPP) -M $(CPPFLAGS) $<
 	@set -e; rm -f $@; \
 	$(CPP) -M $(CFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\.o\)[ :]*,$(OBJODIR)/\1 $@ : ,g' < $@.$$$$ > $@; \


### PR DESCRIPTION
This change is needed because in makefile from my project I can set standards for C and C++ complier like:

CCFLAGS += -Os -std=c11
CCPPFLAGS += -Os -std=c++11

Before this change I couldn't set different standards and I had message like: 

command line option '-std=c11' is valid for C/ObjC but not for C++