### PR TITLE
axTSL client_hello cipher verification failure

### DIFF
--- a/third_party/ssl/ssl/ssl_tls1_svr.c
+++ b/third_party/ssl/ssl/ssl_tls1_svr.c
@@ -150,7 +150,7 @@ static int ICACHE_FLASH_ATTR process_client_hello(SSL *ssl)
 
     offset += id_len;
     cs_len = (buf[offset]<<8) + buf[offset+1];
-    offset += 3;        /* add 1 due to all cipher suites being 8 bit */
+    offset += 2;        /* skip cipher length field */
 
     PARANOIA_CHECK(pkt_size, offset);
 


### PR DESCRIPTION
Fixed axTLS bug of wrong cipher extraction from client_hello during SSL handshake.