### PR TITLE
python -> python2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ endif
 	@echo "SDK_PATH: $(SDK_PATH)"
 	
 ifeq ($(app), 0)
-	@python $(SDK_PATH)/tools/gen_appbin.py $< 0 $(mode) $(freqdiv) $(size_map)
+	@python2 $(SDK_PATH)/tools/gen_appbin.py $< 0 $(mode) $(freqdiv) $(size_map)
 	@mv eagle.app.flash.bin $(BIN_PATH)/eagle.flash.bin
 	@mv eagle.app.v6.irom0text.bin $(BIN_PATH)/eagle.irom0text.bin
 	@rm eagle.app.v6.*
@@ -275,10 +275,10 @@ else
 	@echo ""
 
     ifneq ($(boot), new)
-		@python $(SDK_PATH)/tools/gen_appbin.py $< 1 $(mode) $(freqdiv) $(size_map)
+		@python2 $(SDK_PATH)/tools/gen_appbin.py $< 1 $(mode) $(freqdiv) $(size_map)
 		@echo "Support boot_v1.1 and +"
     else
-		@python $(SDK_PATH)/tools/gen_appbin.py $< 2 $(mode) $(freqdiv) $(size_map)
+		@python2 $(SDK_PATH)/tools/gen_appbin.py $< 2 $(mode) $(freqdiv) $(size_map)
 
     	ifeq ($(size_map), 6)
 		@echo "Support boot_v1.4 and +"

--- a/tools/gen_appbin.py
+++ b/tools/gen_appbin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 # File	: gen_appbin.py
 # This file is part of Espressif's generate bin script.


### PR DESCRIPTION
This allows compilation on systems where the python binary is a link to python3 instead of python2. In fact I'm using ArchLinux and when running make it complains that the `print` command needs parentheses when using the default python3.