### PR TITLE
Allow setting fragment length

### DIFF
--- a/include/openssl/ssl_compat-1.0.h
+++ b/include/openssl/ssl_compat-1.0.h
@@ -30,6 +30,7 @@ typedef struct ssl_ctx SSL_CTX;
 
 #define SSL_get_verify_result ssl_get_verify_result
 #define SSL_set_fd ssl_set_fd
+#define SSL_set_fragment ssl_fragment_length_negotiation
 
 #define SSL_CTX_set_option ssl_ctx_set_option
 

--- a/third_party/openssl/mbedtls_ssl.c
+++ b/third_party/openssl/mbedtls_ssl.c
@@ -58,7 +58,7 @@ struct mbed_ssl
 /*******************************************************************************/
 /*******************************************************************************/
 
-unsigned int max_content_len;
+unsigned int max_content_len = 2048;
 
 /*******************************************************************************/
 /*******************************************************************************/
@@ -104,7 +104,6 @@ LOCAL int mbed_ssl_init(struct mbed_ssl *mbed_ssl, struct ssl_ctx *ssl_ctx)
 
 	mbed_ssl->ssl_ctx = ssl_ctx;
 	SSL_MUTEX_INIT(&ssl_self->mutex);
-	max_content_len = 2048;
 
 	mbedtls_x509_crt_init(&ssl_verify->ca_crt);
 	mbedtls_x509_crt_init(&ssl_verify->own_crt);


### PR DESCRIPTION
Before this change, calling mbed_ssl_init initialized the fragment length to
a default value even if it was explicitly set earlier.

This change also exposes the function to set the length via the OpenSSL
compatibility layer.

Fixes #82.