### PR TITLE
Clearing socket status missed in close() function

### DIFF
--- a/third_party/lwip/api/multi-threads/sockets_mt.c
+++ b/third_party/lwip/api/multi-threads/sockets_mt.c
@@ -347,6 +347,7 @@ LOCAL int lwip_exit_mt_shutdown(int s, int arg)
 
 LOCAL int lwip_exit_mt_close(int s, int arg)
 {
+	SOCK_MT_SET_SHUTDOWN(s, SOCK_MT_STATE_NONE);
 	return 0;
 } 
 


### PR DESCRIPTION
# Symptom
Opened socket never released even though calling socket_close()  function.
So free socket dry up and all tcp/ip communication stops.
( socket_close() internally defined as lwip_close_mt() )

# Fix
  Add a line shown below just behind line number 349 in ESP8266_RTOS_SDK/third_party/lwip/api/multi-threads/socket_mt.c  
`SOCK_MT_SET_SHUTDOWN(s, SOCK_MT_SHUTDOWN_OK);`

# Background
ESP8266_IOT_PLATFORM needs this SDK.
I wrote compiled software to my ESP-WROOM-02 module.
During SmartConfig through web browser, top web page implemented in ESP8266_IOT_PLATFORM/html/plug/index.html never appears.
At that time, logs out from serial port shows  
```
index  1, sockfd 4, dummy ?
index  2, sockfd 5, dummy ?
....
```