### PR TITLE
Fixing lots of compilation warnings:

### DIFF
--- a/components/esp8266/driver/hw_timer.c
+++ b/components/esp8266/driver/hw_timer.c
@@ -23,6 +23,7 @@
  */
 
 #include "esp_common.h"
+#include "freertos/portmacro.h"
 
 #define US_TO_RTC_TIMER_TICKS(t)          \
     ((t) ?          \

--- a/components/esp8266/driver/i2c_master.c
+++ b/components/esp8266/driver/i2c_master.c
@@ -10,7 +10,9 @@
 *******************************************************************************/
 #include "c_types.h"
 #include "esp8266/ets_sys.h"
+#include "esp_misc.h"
 #include "gpio.h"
+#include "freertos/portmacro.h"
 
 #include "i2c_master.h"
 

--- a/components/esp8266/driver/spi_interface.c
+++ b/components/esp8266/driver/spi_interface.c
@@ -24,6 +24,7 @@
 #include "esp8266/ets_sys.h"
 #include "esp8266/pin_mux_register.h"
 #include "esp_libc.h"
+#include "freertos/portmacro.h"
 //*****************************************************************************
 //
 // Make sure all of the definitions in this header have a C binding.
@@ -457,7 +458,7 @@ int ICACHE_FLASH_ATTR SPIMasterRecvStatus(SpiNum spiNum)
 
     while (READ_PERI_REG(SPI_CMD(spiNum))&SPI_USR);
 
-    uint8_t data = (uint8)(READ_PERI_REG(SPI_W0(spiNum)) & 0xff);
+    (void)(READ_PERI_REG(SPI_W0(spiNum)) & 0xff);
     SHOWREG();
 
     return (uint8)(READ_PERI_REG(SPI_W0(spiNum)) & 0xff);

--- a/components/esp8266/driver/uart.c
+++ b/components/esp8266/driver/uart.c
@@ -29,6 +29,7 @@
 #include "freertos/queue.h"
 
 #include "uart.h"
+#include "esp8266/rom_functions.h"
 
 enum {
     UART_EVENT_RX_CHAR,
@@ -82,6 +83,7 @@ uart0_write_char(char c)
     }
 }
 
+#if 0
 LOCAL void
 uart_rx_intr_handler_ssc(void *arg)
 {
@@ -109,7 +111,6 @@ uart_rx_intr_handler_ssc(void *arg)
     portEND_SWITCHING_ISR(xHigherPriorityTaskWoken);
 }
 
-#if 0
 LOCAL void
 uart_config(uint8 uart_no, UartDevice *uart)
 {
@@ -149,6 +150,7 @@ uart_config(uint8 uart_no, UartDevice *uart)
 }
 #endif
 
+#if 0
 LOCAL void
 uart_task(void *pvParameters)
 {
@@ -170,7 +172,6 @@ uart_task(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-#if 0
 void
 uart_init(void)
 {
@@ -351,11 +352,9 @@ uart0_rx_intr_handler(void *para)
     /* uart0 and uart1 intr combine togther, when interrupt occur, see reg 0x3ff20020, bit2, bit0 represents
     * uart1 and uart0 respectively
     */
-    uint8 RcvChar;
     uint8 uart_no = UART0;//UartDev.buff_uart_no;
     uint8 fifo_len = 0;
     uint8 buf_idx = 0;
-    uint8 fifo_tmp[128] = {0};
 
     uint32 uart_intr_status = READ_PERI_REG(UART_INT_ST(uart_no)) ;
 

--- a/components/esp8266/include/driver/spi_interface.h
+++ b/components/esp8266/include/driver/spi_interface.h
@@ -126,7 +126,9 @@ typedef enum
     SpiPinCS_2 = 2,
 } SpiPinCS;
 
+#ifndef __GNUC__
 #pragma pack (1)
+#endif
 
 /**
  * @brief SPI attribute
@@ -137,7 +139,11 @@ typedef struct
     SpiSubMode     subMode;        ///< SPI SPI_CPOL SPI_CPHA mode
     SpiSpeed       speed;          ///< SPI Clock
     SpiBitOrder    bitOrder;       ///< SPI bit order
-} SpiAttr;
+} SpiAttr
+#ifndef __GNUC__
+__attribute ((packed))
+#endif
+;
 
 /**
  * @brief SPI attribute
@@ -150,9 +156,15 @@ typedef struct
     uint8_t     addrLen;        ///< Address byte length
     uint32_t    *data;          ///< Point to data buffer
     uint8_t     dataLen;        ///< Data byte length.
-} SpiData;
+} SpiData
+#ifndef __GNUC__
+__attribute ((packed))
+#endif
+;
 
+#ifndef __GNUC__
 #pragma upack (1)
+#endif
 
 #define SHOWREG() __ShowRegValue(__func__, __LINE__);
 

--- a/components/esp8266/include/esp8266/rom_functions.h
+++ b/components/esp8266/include/esp8266/rom_functions.h
@@ -1,0 +1,21 @@
+#ifndef _ROM_FUNCTIONS_H
+#define _ROM_FUNCTIONS_H
+
+#include <stdint.h>
+
+uint32_t Wait_SPI_Idle();
+
+void uart_div_modify(uint32_t uart_no, uint32_t baud_div);
+
+void ets_delay_us(uint32_t us);
+int ets_printf(const char *fmt, ...)
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)));
+#endif
+;
+
+void system_soft_wdt_feed();
+
+void Cache_Read_Enable_New();
+
+#endif

--- a/components/esp8266/source/esp_wifi_os_adapter.c
+++ b/components/esp8266/source/esp_wifi_os_adapter.c
@@ -42,7 +42,7 @@ static void *task_create_wrapper(void *task_func, const char *name, uint32_t sta
     portBASE_TYPE ret;
     xTaskHandle handle;
 
-    ret = xTaskCreate(task_func, (const signed char *)name, stack_depth, param, prio, &handle);
+    ret = xTaskCreate(task_func, name, stack_depth, param, prio, &handle);
 
     return ret == pdPASS ? handle : NULL;
 }
@@ -248,7 +248,7 @@ static uint32_t get_free_heap_size_wrapper(void)
 
 static void *timer_create_wrapper(const char *name, uint32_t period_ticks, bool auto_load, void *arg, void (*cb)(void *timer))
 {
-    return xTimerCreate((const signed char *)name, period_ticks, auto_load, arg, (tmrTIMER_CALLBACK)cb);
+    return xTimerCreate(name, period_ticks, auto_load, arg, (tmrTIMER_CALLBACK)cb);
 }
 
 static void *timer_get_arg_wrapper(void *timer)

--- a/components/freertos/port/esp8266/heap_5.c
+++ b/components/freertos/port/esp8266/heap_5.c
@@ -116,12 +116,11 @@ task.h is included from an application file. */
 #include "freertos/task.h"
 
 #include "esp8266/ets_sys.h"
+#include "esp8266/rom_functions.h"
 
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #define mtCOVERAGE_TEST_MARKER()
-#define traceFREE(...)
-#define traceMALLOC(...)
 
 #if 1
 #define mem_printf(fmt, args...) ets_printf(fmt,## args)
@@ -253,7 +252,7 @@ void pvShowMalloc()
 		const char *file_name_printf;
 //ets_printf("sh2,");
 		file_name_printf = vGetFileName(file_name, pxIterator->pxNextFreeBlock->file);
-		os_printf("F:%s\tL:%u\tmalloc %d\t@ %x\n", file_name_printf, pxIterator->pxNextFreeBlock->line, pxIterator->pxNextFreeBlock->xBlockSize - 0x80000000, ( void * ) ( ( ( unsigned char * ) pxIterator->pxNextFreeBlock ) + uxHeapStructSize));
+		os_printf("F:%s\tL:%u\tmalloc %d\t@ %p\n", file_name_printf, pxIterator->pxNextFreeBlock->line, pxIterator->pxNextFreeBlock->xBlockSize - 0x80000000, ( void * ) ( ( ( unsigned char * ) pxIterator->pxNextFreeBlock ) + uxHeapStructSize));
 //ets_printf("sh3,");
 //		ets_delay_us(2000);
         system_soft_wdt_feed();
@@ -531,7 +530,7 @@ BlockLink_t *pxLink;
 				ETS_INTR_LOCK();
 #ifdef MEMLEAK_DEBUG
 				if(prvRemoveBlockFromUsedList(pxLink) < 0){
-					ets_printf("%x already freed\n", pv);
+					ets_printf("%p already freed\n", pv);
 				}
 				else
 #endif
@@ -865,4 +864,3 @@ const HeapRegion_t *pxHeapRegion;
     yFreeBytesRemaining = 0;
 #endif
 }
-

--- a/components/freertos/port/esp8266/include/freertos/xtensa_rtos.h
+++ b/components/freertos/port/esp8266/include/freertos/xtensa_rtos.h
@@ -78,8 +78,10 @@ Called after minimal context has been saved, with interrupts disabled.
 RTOS port can call0 _xt_context_save to save the rest of the context.
 May only be called from assembly code by the 'call0' instruction.
 */
-// void XT_RTOS_INT_ENTER(void)
 #define XT_RTOS_INT_ENTER   _xt_int_enter
+#ifndef __ASSEMBLER__
+void XT_RTOS_INT_ENTER();
+#endif
 
 /*
 Inform RTOS of completion of an interrupt handler, and give control to
@@ -91,8 +93,10 @@ leaving only a minimal part of the context to be restored by the exit
 dispatcher. This function does not return to the place it was called from.
 May only be called from assembly code by the 'call0' instruction.
 */
-// void XT_RTOS_INT_EXIT(void)
 #define XT_RTOS_INT_EXIT    _xt_int_exit
+#ifndef __ASSEMBLER__
+void XT_RTOS_INT_EXIT();
+#endif
 
 /*
 Inform RTOS of the occurrence of a tick timer interrupt.
@@ -100,8 +104,10 @@ If RTOS has no tick timer, leave XT_RTOS_TIMER_INT undefined.
 May be coded in or called from C or assembly, per ABI conventions.
 RTOS may optionally define XT_TICK_PER_SEC in its own way (eg. macro).
 */
-// void XT_RTOS_TIMER_INT(void)
 #define XT_RTOS_TIMER_INT   _xt_timer_int
+#ifndef __ASSEMBLER__
+void XT_RTOS_TIMER_INT();
+#endif
 
 /*
 Return in a15 the base address of the co-processor state save area for the 

--- a/components/freertos/port/esp8266/panic.c
+++ b/components/freertos/port/esp8266/panic.c
@@ -19,6 +19,7 @@
 #include "esp8266/ets_sys.h"
 #include "esp8266/eagle_soc.h"
 #include "esp8266/uart_register.h"
+#include "freertos/portmacro.h"
 
 /*
  * Todo: panic output UART ID, we may add it to 'kconfig' to select target UART.

--- a/components/freertos/port/esp8266/port.c
+++ b/components/freertos/port/esp8266/port.c
@@ -80,14 +80,14 @@
 #define PORT_ASSERT(x) do { if (!(x)) {ets_printf("%s %u\n", "rtos_port", __LINE__); while(1){}; }} while (0)
 
 extern char NMIIrqIsOn;
-static char HdlMacSig = 0;
-static char SWReq = 0;
+static uint8_t HdlMacSig = 0;
+static uint8_t SWReq = 0;
 
 unsigned cpu_sr;
 
 /* Each task maintains its own interrupt status in the critical nesting
 variable. */
-static unsigned portBASE_TYPE uxCriticalNesting = 0;
+static unsigned int uxCriticalNesting = 0;
 
 void vPortEnterCritical(void);
 void vPortExitCritical(void);
@@ -242,7 +242,7 @@ void IRAM_ATTR vPortExitCritical(void)
                 }
             }
         } else {
-            ets_printf("E:C:%lu\n", uxCriticalNesting);
+            ets_printf("E:C:%u\n", uxCriticalNesting);
             PORT_ASSERT((uxCriticalNesting > 0));
         }
     }
@@ -250,9 +250,9 @@ void IRAM_ATTR vPortExitCritical(void)
 
 void ShowCritical(void)
 {
-    os_printf("ShowCritical:%lu\n", uxCriticalNesting);
-    os_printf("HdlMacSig:%c\n", HdlMacSig);
-    os_printf("SWReq:%c\n", SWReq);
+    os_printf("ShowCritical:%u\n", uxCriticalNesting);
+    os_printf("HdlMacSig:%u\n", HdlMacSig);
+    os_printf("SWReq:%u\n", SWReq);
 
     ets_delay_us(50000);
 }

--- a/components/freertos/port/esp8266/port.c
+++ b/components/freertos/port/esp8266/port.c
@@ -75,6 +75,7 @@
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include "freertos/xtensa_rtos.h"
+#include "esp8266/rom_functions.h"
 
 #define PORT_ASSERT(x) do { if (!(x)) {ets_printf("%s %u\n", "rtos_port", __LINE__); while(1){}; }} while (0)
 
@@ -90,6 +91,10 @@ static unsigned portBASE_TYPE uxCriticalNesting = 0;
 
 void vPortEnterCritical(void);
 void vPortExitCritical(void);
+
+void _xt_timer_int1(void);
+
+
 /*
  * See header file for description.
  */
@@ -237,7 +242,7 @@ void IRAM_ATTR vPortExitCritical(void)
                 }
             }
         } else {
-            ets_printf("E:C:%d\n", uxCriticalNesting);
+            ets_printf("E:C:%lu\n", uxCriticalNesting);
             PORT_ASSERT((uxCriticalNesting > 0));
         }
     }
@@ -245,9 +250,9 @@ void IRAM_ATTR vPortExitCritical(void)
 
 void ShowCritical(void)
 {
-    os_printf("ShowCritical:%d\n", uxCriticalNesting);
-    os_printf("HdlMacSig:%d\n", HdlMacSig);
-    os_printf("SWReq:%d\n", SWReq);
+    os_printf("ShowCritical:%lu\n", uxCriticalNesting);
+    os_printf("HdlMacSig:%c\n", HdlMacSig);
+    os_printf("SWReq:%c\n", SWReq);
 
     ets_delay_us(50000);
 }

--- a/components/mqtt/paho/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
+++ b/components/mqtt/paho/MQTTClient-C/src/FreeRTOS/MQTTFreeRTOS.c
@@ -68,7 +68,7 @@ void TimerCountdown(Timer* timer, unsigned int timeout)
 int TimerLeftMS(Timer* timer)
 {
     xTaskCheckForTimeOut(&timer->xTimeOut, &timer->xTicksToWait); /* updates xTicksToWait to the number left */
-    return (timer->xTicksToWait < 0) ? 0 : (timer->xTicksToWait * portTICK_RATE_MS);
+    return timer->xTicksToWait * portTICK_RATE_MS;
 }
 
 
@@ -90,7 +90,6 @@ static int esp_read(Network* n, unsigned char* buffer, unsigned int len, unsigne
     portTickType xTicksToWait = timeout_ms / portTICK_RATE_MS; /* convert milliseconds to ticks */
     xTimeOutType xTimeOut;
     int recvLen = 0;
-    int recv_timeout = timeout_ms;
     int rc = 0;
 
     struct timeval timeout;
@@ -128,7 +127,6 @@ static int esp_write(Network* n, unsigned char* buffer, unsigned int len, unsign
     portTickType xTicksToWait = timeout_ms / portTICK_RATE_MS; /* convert milliseconds to ticks */
     xTimeOutType xTimeOut;
     int sentLen = 0;
-    int send_timeout = timeout_ms;
     int rc = 0;
     int readysock;
 

--- a/components/newlib/newlib/port/syscall.c
+++ b/components/newlib/newlib/port/syscall.c
@@ -114,7 +114,7 @@ void *_calloc_r(struct _reent *r, size_t c, size_t s)
     return p;
 }
 
-void *_free_r(struct _reent *r, void *ptr)
+void _free_r(struct _reent *r, void *ptr)
 {
     vPortFree(ptr);
 }

--- a/components/ssl/mbedtls/port/esp8266/esp_hardware.c
+++ b/components/ssl/mbedtls/port/esp8266/esp_hardware.c
@@ -19,6 +19,7 @@
 #endif
 
 #include <sys/types.h>
+#include "esp_libc.h"
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 /**
@@ -34,6 +35,6 @@ int mbedtls_hardware_poll( void *data,
 {
     os_get_random(output, len);
     *olen = len;
+    return 0;
 }
 #endif
-

--- a/components/ssl/mbedtls/port/openssl/source/platform/ssl_pm_extend.c
+++ b/components/ssl/mbedtls/port/openssl/source/platform/ssl_pm_extend.c
@@ -173,9 +173,9 @@ int base64_encode(uint8* dst, size_t dlen, size_t* olen,
 
         *olen = p - dst;
         *p  = 0;
-
-        return 0;
     }
+
+    return 0;
 }
 
 /*
@@ -214,7 +214,7 @@ int SSL_CTX_load_verify_locations(SSL_CTX* ctx, const char* CAfile,
                                   const char* CApath)
 {
     X509* cacrt = NULL;
-    cacrt = d2i_X509(NULL, CAfile, strlen(CAfile));
+    cacrt = d2i_X509(NULL, (const unsigned char *)CAfile, strlen(CAfile));
 
     if (cacrt) {
         SSL_CTX_add_client_CA(ctx, cacrt);
@@ -343,7 +343,7 @@ If buf is NULL , the error string is placed in a static buffer.
 */
 char* ERR_error_string(unsigned long e, char* ret)
 {
-    return;
+    return NULL;
 }
 
 /*


### PR DESCRIPTION
fix(esp8266): Adding includes for missing symbols.
Removing unused variables.
Use GCC's packing attribute when using GCC. Skip unsupported packing pragmas if
not using GCC.
Add rom_functions.h for symbols that come from the ESP ROM. Add attributes on
ets_printf so GCC will check the syntax of the formatting string and types of
the arguments.

fix(freertos): Define functions that are useful.
Use correct printf symbols when printing.

fix(mqtt): `xTicksToWait` is unsigned, can't check for less than zero. Remove
unused variables.

fix(newlib): `_free_r()` returns `void`, not `void *`.

fix(ssl): Make sure functions always return a value.