### PR TITLE
Fixed toolchain detection in project makefile

### DIFF
--- a/components/esp8266/include/esp8266/ets_sys.h
+++ b/components/esp8266/include/esp8266/ets_sys.h
@@ -38,6 +38,7 @@
 
 extern char NMIIrqIsOn;
 extern uint32_t WDEV_INTEREST_EVENT;
+extern void vPortEnterCritical();
 
 #define INT_ENA_WDEV        0x3ff20c18
 #define WDEV_TSF0_REACH_INT (BIT(27))

--- a/make/project.mk
+++ b/make/project.mk
@@ -546,19 +546,19 @@ list-components:
 print_flash_cmd:
 	echo $(ESPTOOL_WRITE_FLASH_OPTIONS) $(ESPTOOL_ALL_FLASH_ARGS) | sed -e 's:'$(PWD)/build/'::g'
 
-# Check toolchain version using the output of xtensa-esp32-elf-gcc --version command.
+# Check toolchain version using the output of xtensa-lx106-elf-gcc --version command.
 # The output normally looks as follows
-#     xtensa-esp32-elf-gcc (crosstool-NG crosstool-ng-1.22.0-59-ga194053) 4.8.5
+#     xtensa-lx106-elf-gcc (crosstool-NG 1.20.0) 4.8.2
 # The part in brackets is extracted into TOOLCHAIN_COMMIT_DESC variable,
 # the part after the brackets is extracted into TOOLCHAIN_GCC_VER.
 ifdef CONFIG_TOOLPREFIX
 ifndef MAKE_RESTARTS
-TOOLCHAIN_COMMIT_DESC := $(shell $(CC) --version | sed -E -n 's|.*crosstool-ng-([0-9]+).([0-9]+).([0-9]+)-([0-9]+)-g([0-9a-f]{7}).*|\1.\2.\3-\4-g\5|gp')
-TOOLCHAIN_GCC_VER := $(shell $(CC) --version | sed -E -n 's|xtensa-esp32-elf-gcc.*\ \(.*\)\ (.*)|\1|gp')
+TOOLCHAIN_COMMIT_DESC := $(shell $(CC) --version | sed -E -n 's|.*crosstool-NG ([0-9]+).([0-9]+).([0-9]+).*|\1.\2.\3|gp')
+TOOLCHAIN_GCC_VER := $(shell $(CC) --version | sed -E -n 's|xtensa-lx106-elf.*\ \(.*\)\ (.*)|\1|gp')
 
 # Officially supported version(s)
-SUPPORTED_TOOLCHAIN_COMMIT_DESC := 1.22.0-80-g6c4433a
-SUPPORTED_TOOLCHAIN_GCC_VERSIONS := 5.2.0
+SUPPORTED_TOOLCHAIN_COMMIT_DESC := 1.20.0
+SUPPORTED_TOOLCHAIN_GCC_VERSIONS := 4.8.2
 
 ifdef TOOLCHAIN_COMMIT_DESC
 ifneq ($(TOOLCHAIN_COMMIT_DESC), $(SUPPORTED_TOOLCHAIN_COMMIT_DESC))


### PR DESCRIPTION
Make tries to detect a version of the ESP32 toolchain and issue a warning during compiling time because it's not detected.
This PR changes that to detect the esp8266 toolchain recommended by the README (Arduino pre-built gcc 4.8.2).