### PR TITLE
Fixed invalid function descriptions

### DIFF
--- a/components/newlib/newlib/port/syscall.c
+++ b/components/newlib/newlib/port/syscall.c
@@ -40,12 +40,12 @@ int _open_r(struct _reent *r, const char *filename, int flags, int mode)
     return 0;
 }
 
-int _read_r(struct _reent *r, int fd, void *buf, int len)
+_ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t len)
 {
     return 0;
 }
 
-int _write_r(struct _reent *r, int fd, void *buf, int len)
+_ssize_t _write_r(struct _reent *r, int fd, void *buf, size_t len)
 {
     int i;
     const char *cbuf = buf;
@@ -83,7 +83,7 @@ int _fstat_r(struct _reent *r, int fd, struct stat *s)
     return 0;
 }
 
-void _sbrk_r(void *ptr, int incr)
+void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
 {
     return ;
 }


### PR DESCRIPTION
After last changes of the port version some extern declared function changes from 
newlib/include/reent.h didn't found their way to syscall.c

Which caused compile problems 

Update: It's only related if the reent option of the freeRTOS is turned on within the sdkconfig