### PR TITLE
feat(spiffs): Make SPIFFS API more POSIX compatible.

### DIFF
--- a/components/spiffs/include/spiffs/esp_spiffs.h
+++ b/components/spiffs/include/spiffs/esp_spiffs.h
@@ -26,6 +26,7 @@
 #define __ESP_SPIFFS_H__
 
 #include "spiffs/spiffs.h"
+#include <fcntl.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +77,15 @@ void esp_spiffs_deinit(u8_t format);
 /**
   * @}
   */
+
+int _spiffs_open_r(struct _reent *r, const char *filename, int flags, int mode);
+_ssize_t _spiffs_read_r(struct _reent *r, int fd, void *buf, size_t len);
+_ssize_t _spiffs_write_r(struct _reent *r, int fd, void *buf, size_t len);
+_off_t _spiffs_lseek_r(struct _reent *r, int fd, _off_t where, int whence);
+int _spiffs_close_r(struct _reent *r, int fd);
+int _spiffs_rename_r(struct _reent *r, const char *from, const char *to);
+int _spiffs_unlink_r(struct _reent *r, const char *filename);
+int _spiffs_fstat_r(struct _reent *r, int fd, struct stat *s);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
o Fix lseek and read so that they have POSIX semantics.
o Expose the _sfpiffs_* functions. This can be further improved by
  a proper integration into newlib's functions, but now they work as a
  thin wrapper around the native SPIFFS API but with known semantics.