### PR TITLE
Adding mbedtls configurability for

### DIFF
--- a/components/ssl/Kconfig
+++ b/components/ssl/Kconfig
@@ -56,6 +56,10 @@ config MBEDTLS_DEBUG_LEVEL
    help
        Mbedtls debugging level.
 
+config MBEDTLS_STRERROR
+    bool "Enable mbedtls_strerror function"
+    default n
+
 config MBEDTLS_HAVE_TIME
    bool "Enable mbedtls time"
    default y

--- a/components/ssl/mbedtls/port/esp8266/include/mbedtls/esp_config.h
+++ b/components/ssl/mbedtls/port/esp8266/include/mbedtls/esp_config.h
@@ -2122,7 +2122,9 @@
  *
  * This module enables mbedtls_strerror().
  */
-//#define MBEDTLS_ERROR_C
+#ifdef CONFIG_MBEDTLS_STRERROR
+#define MBEDTLS_ERROR_C
+#endif
 
 /**
  * \def MBEDTLS_GCM_C


### PR DESCRIPTION
- MBEDTLS_ERROR_C: mbedtls_strerror() function
- MBEDTLS_CERTS_C: static diagnostic-only certificates
- MBEDTLS_SSL_CACHE_C
- MBEDTLS_SSL_COOKIE_C: DTLS IP-spoof/DoS protection