### PR TITLE
LWIP mDNS feature

### DIFF
--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -230,6 +230,14 @@ config DNS_MAX_SERVERS
     range 1 5
     default 2
 
+config LWIP_MDNS_RESPONDER
+    bool "Enable mDNS responder"
+    default n
+    select LWIP_NETIF_CLIENT_DATA
+    help
+        This requires an LWIP_NUM_NETIF_CLIENT_DATA slot, so that option
+        must be >= 1
+
 menuconfig LWIP_NETIF_CLIENT_DATA
     bool "Enable per-interface client data"
     default n
@@ -239,8 +247,8 @@ menuconfig LWIP_NETIF_CLIENT_DATA
 
 config LWIP_NUM_NETIF_CLIENT_DATA
     int "Enable client data array in netif"
-    default 1
-    range 1 8
+    default 2
+    range 1 10
     depends on LWIP_NETIF_CLIENT_DATA
     help
         Number of slots available to associate your own app data
@@ -249,6 +257,9 @@ config LWIP_NUM_NETIF_CLIENT_DATA
         From LWIP header: "Number of clients that may store data in 
         client_data member array of struct netif."
 
+        This is set to 2 initially just incase this has been auto enabled
+        by more than one dependency
+
 menuconfig LWIP_NETIF_LOOPBACK
     bool "Enable per-interface loopback"
     default n
@@ -256,14 +267,6 @@ menuconfig LWIP_NETIF_LOOPBACK
         Enabling this option means that if a packet is sent with a destination
         address equal to the interface's own IP address, it will "loop back" and
         be received by this interface.
-
-config LWIP_MDNS_RESPONDER
-    bool "Enable mDNS responder"
-    default n
-    depends on LWIP_NETIF_CLIENT_DATA
-    help
-        This requires an LWIP_NUM_NETIF_CLIENT_DATA slot, so that option
-        must be >= 1
 
 config LWIP_LOOPBACK_MAX_PBUFS
     int "Max queued loopback packets per interface"

--- a/components/lwip/Kconfig
+++ b/components/lwip/Kconfig
@@ -230,6 +230,25 @@ config DNS_MAX_SERVERS
     range 1 5
     default 2
 
+menuconfig LWIP_NETIF_CLIENT_DATA
+    bool "Enable per-interface client data"
+    default n
+    help
+        Enabling this pre-allocates extra space for each netif
+        for your own app to store data in
+
+config LWIP_NUM_NETIF_CLIENT_DATA
+    int "Enable client data array in netif"
+    default 1
+    range 1 8
+    depends on LWIP_NETIF_CLIENT_DATA
+    help
+        Number of slots available to associate your own app data
+        to a particular netif
+
+        From LWIP header: "Number of clients that may store data in 
+        client_data member array of struct netif."
+
 menuconfig LWIP_NETIF_LOOPBACK
     bool "Enable per-interface loopback"
     default n
@@ -237,6 +256,14 @@ menuconfig LWIP_NETIF_LOOPBACK
         Enabling this option means that if a packet is sent with a destination
         address equal to the interface's own IP address, it will "loop back" and
         be received by this interface.
+
+config LWIP_MDNS_RESPONDER
+    bool "Enable mDNS responder"
+    default n
+    depends on LWIP_NETIF_CLIENT_DATA
+    help
+        This requires an LWIP_NUM_NETIF_CLIENT_DATA slot, so that option
+        must be >= 1
 
 config LWIP_LOOPBACK_MAX_PBUFS
     int "Max queued loopback packets per interface"

--- a/components/lwip/component.mk
+++ b/components/lwip/component.mk
@@ -11,6 +11,7 @@ COMPONENT_ADD_INCLUDEDIRS += include/lwip/apps \
 COMPONENT_SRCDIRS += apps/dhcpserver \
                      apps/multi-threads \
                      lwip/src/api \
+                     lwip/src/apps/mdns \
                      lwip/src/apps/sntp \
                      lwip/src/core \
                      lwip/src/core/ipv4 \

--- a/components/lwip/port/esp8266/include/lwipopts.h
+++ b/components/lwip/port/esp8266/include/lwipopts.h
@@ -1150,10 +1150,19 @@ void *memp_malloc_ll(size_t type);
  * LWIP_NUM_NETIF_CLIENT_DATA: Number of clients that may store
  * data in client_data member array of struct netif.
  */
+#ifdef CONFIG_LWIP_NETIF_CLIENT_DATA
+#define LWIP_NUM_NETIF_CLIENT_DATA            CONFIG_LWIP_NUM_NETIF_CLIENT_DATA
+#else
 #define LWIP_NUM_NETIF_CLIENT_DATA            0
+#endif
 /**
  * @}
  */
+
+
+ #ifdef CONFIG_LWIP_MDNS_RESPONDER
+ #define LWIP_MDNS_RESPONDER                  1
+ #endif
 
 /*
    ------------------------------------


### PR DESCRIPTION
Modified project & kconfig settings to permit lwip's mDNS app.

Compiles and lightly tested (`mdns_resp_add_netif` works as expected)