### PR TITLE
Fix bug of not being able to send a single Byte with i2c_master_write

### DIFF
--- a/components/esp8266/driver/i2c.c
+++ b/components/esp8266/driver/i2c.c
@@ -500,7 +500,7 @@ static void i2c_master_cmd_begin_static(i2c_port_t i2c_num)
                     i2c_master_set_dc(i2c_num, i2c_last_state[i2c_num]->sda, 0);
 
                     for (i = 7; i >= 0; i--) {
-                        if (cmd->byte_num == 1) {
+                        if (cmd->byte_num == 1 && cmd->data == NULL) {
                             dat = (cmd->byte_cmd) >> i;
                         } else {
                             dat = ((uint8_t) * (cmd->data + len)) >> i;


### PR DESCRIPTION
When using the i2c_master_write function without this patch with data length of 1 like used in the Espressif example code it sends 0x00. https://github.com/espressif/ESP8266_RTOS_SDK/blob/master/examples/peripherals/i2c/main/user_main.c#L202