### PR TITLE
Fixed broken include path

### DIFF
--- a/components/esp8266/include/esp8266/esp8266.h
+++ b/components/esp8266/include/esp8266/esp8266.h
@@ -25,7 +25,7 @@
 #ifndef __ESP8266_H__
 #define __ESP8266_H__
 
-#include "ets_sys.h"
+#include "rom/ets_sys.h"
 #include "eagle_soc.h"
 #include "gpio_register.h"
 #include "pin_mux_register.h"


### PR DESCRIPTION
It appears, the include path to ets_sys.h was wrong.