### PR TITLE
Fix the problem that causes other pins to be abnormal in pwm

### DIFF
--- a/components/esp8266/driver/pwm.c
+++ b/components/esp8266/driver/pwm.c
@@ -295,6 +295,7 @@ static void IRAM_ATTR pwm_timer_intr_handler(void)
                 mask = mask | pwm_obj->single->run_pwm_param[pwm_obj->single->run_channel_num - 1].io_set_mask;
                 REG_WRITE(PERIPHS_GPIO_BASEADDR + GPIO_OUT_ADDRESS, mask);
             } else {
+                mask = REG_READ(PERIPHS_GPIO_BASEADDR + GPIO_OUT_ADDRESS);
                 mask = mask & (~(pwm_obj->single->run_pwm_param[pwm_obj->current_channel - 1].io_clr_mask));
                 mask = mask | (pwm_obj->single->run_pwm_param[pwm_obj->current_channel - 1].io_set_mask);
                 REG_WRITE(PERIPHS_GPIO_BASEADDR + GPIO_OUT_ADDRESS, mask);


### PR DESCRIPTION
In pwm, when updating the state of the pins used by pwm, we need to get the state of other pins first, and then modify the state of the corresponding channel pwm pin through mask. In the previous code, other pins functions were abnormal when using pwm because they write mask state directly without obtaining the current pin state first.This submission adds code to get the status of the previous pins to ensure that other pins are stable. Fixed the function of pwm.