### PR TITLE
fix (spi_oled_example) commond bug

### DIFF
--- a/examples/peripherals/spi_oled/main/spi_oled_example_main.c
+++ b/examples/peripherals/spi_oled/main/spi_oled_example_main.c
@@ -113,7 +113,7 @@ static esp_err_t oled_set_pos(uint8_t x_start, uint8_t y_start)
 {
     oled_write_cmd(0xb0 + y_start);
     oled_write_cmd(((x_start & 0xf0) >> 4) | 0x10);
-    oled_write_cmd((x_start & 0x0f) | 0x01);
+    oled_write_cmd((x_start & 0x0f));
     return ESP_OK;
 }
 


### PR DESCRIPTION
根据SSD1306的手册
设置点坐标高4位时 范围是 0x10-0x1F 需要加入掩码0x10
设置坐标的低4位时 范围为 0x00-0x0F 直接写入