### PR TITLE
Fixed missing include in driver/gpio.h for gpio_pad_select_gpio()

### DIFF
--- a/components/esp8266/include/driver/gpio.h
+++ b/components/esp8266/include/driver/gpio.h
@@ -21,6 +21,7 @@
 #include "esp8266/eagle_soc.h"
 #include "esp8266/pin_mux_register.h"
 #include "esp8266/gpio_register.h"
+#include "rom/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Inline with ESP-IDF, this fix makes **gpio_pad_select_gpio()** accessible via driver/gpio.h without needing a separate include for the rom/gpio.h 