### PR TITLE
Ported idf_size.py from esp-idf to esp8266 (GIT8266O-152)

### DIFF
--- a/tools/idf_size.py
+++ b/tools/idf_size.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+#
+# esp-idf alternative to "size" to print ELF file sizes, also analyzes
+# the linker map file to dump higher resolution details.
+#
+# Includes information which is not shown in "xtensa-esp32-elf-size",
+# or easy to parse from "xtensa-esp32-elf-objdump" or raw map files.
+#
+# Copyright 2017-2018 Espressif Systems (Shanghai) PTE LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+from __future__ import unicode_literals
+import argparse
+import re
+import os.path
+
+DEFAULT_TOOLCHAIN_PREFIX = "xtensa-esp32-elf-"
+
+
+def scan_to_header(f, header_line):
+    """ Scan forward in a file until you reach 'header_line', then return """
+    for line in f:
+        if line.strip() == header_line:
+            return
+    raise RuntimeError("Didn't find line '%s' in file" % header_line)
+
+
+def load_map_data(map_file):
+    memory_config = load_memory_config(map_file)
+    sections  = load_sections(map_file)
+    return memory_config, sections
+
+
+def load_memory_config(map_file):
+    """ Memory Configuration section is the total size of each output section """
+    result = {}
+    scan_to_header(map_file, "Memory Configuration")
+    RE_MEMORY_SECTION = r"(?P<name>[^ ]+) +0x(?P<origin>[\da-f]+) +0x(?P<length>[\da-f]+)"
+    for line in map_file:
+        m = re.match(RE_MEMORY_SECTION, line)
+        if m is None:
+            if len(result) == 0:
+                continue  # whitespace or a header, before the content we want
+            else:
+                return result  # we're at the end of the Memory Configuration
+        section = {
+            "name": m.group("name"),
+            "origin": int(m.group("origin"), 16),
+            "length": int(m.group("length"), 16),
+        }
+
+        if section["name"] != "*default*":
+            result[section["name"]] = section
+
+    raise RuntimeError("End of file while scanning memory configuration?")
+
+
+def load_sections(map_file):
+    """ Load section size information from the MAP file.
+
+    Returns a dict of 'sections', where each key is a section name and the value
+    is a dict with details about this section, including a "sources" key which holds a list of source file line
+    information for each symbol linked into the section.
+    """
+    scan_to_header(map_file, "Linker script and memory map")
+    sections = {}
+    section = None
+    sym_backup = None
+    for line in map_file:
+        # output section header, ie '.iram0.text     0x0000000040080400    0x129a5'
+        RE_SECTION_HEADER = r"(?P<name>[^ ]+) +0x(?P<address>[\da-f]+) +0x(?P<size>[\da-f]+)$"
+        m = re.match(RE_SECTION_HEADER, line)
+        if m is not None:  # start of a new section
+            section = {
+                "name": m.group("name"),
+                "address": int(m.group("address"), 16),
+                "size": int(m.group("size"), 16),
+                "sources": [],
+            }
+            sections[section["name"]] = section
+            continue
+
+        # source file line, ie
+        # 0x0000000040080400       0xa4 /home/gus/esp/32/idf/examples/get-started/hello_world/build/esp32/libesp32.a(cpu_start.o)
+        RE_SOURCE_LINE = r"\s*(?P<sym_name>\S*).* +0x(?P<address>[\da-f]+) +0x(?P<size>[\da-f]+) (?P<archive>.+\.a)\((?P<object_file>.+\.ob?j?)\)"
+
+        m = re.match(RE_SOURCE_LINE, line, re.M)
+        if not m:
+            # cmake build system links some object files directly, not part of any archive
+            RE_SOURCE_LINE = r"\s*(?P<sym_name>\S*).* +0x(?P<address>[\da-f]+) +0x(?P<size>[\da-f]+) (?P<object_file>.+\.ob?j?)"
+            m = re.match(RE_SOURCE_LINE, line)
+        if section is not None and m is not None:  # input source file details=ma,e
+            sym_name = m.group("sym_name") if len(m.group("sym_name")) > 0 else sym_backup
+            try:
+                archive = m.group("archive")
+            except IndexError:
+                archive = "(exe)"
+
+            source = {
+                "size": int(m.group("size"), 16),
+                "address": int(m.group("address"), 16),
+                "archive": os.path.basename(archive),
+                "object_file": os.path.basename(m.group("object_file")),
+                "sym_name": sym_name,
+            }
+            source["file"] = "%s:%s" % (source["archive"], source["object_file"])
+            section["sources"] += [source]
+
+        # In some cases the section name appears on the previous line, back it up in here
+        RE_SYMBOL_ONLY_LINE = r"^ (?P<sym_name>\S*)$"
+        m = re.match(RE_SYMBOL_ONLY_LINE, line)
+        if section is not None and m is not None:
+            sym_backup = m.group("sym_name")
+
+    return sections
+
+
+def sizes_by_key(sections, key):
+    """ Takes a dict of sections (from load_sections) and returns
+    a dict keyed by 'key' with aggregate output size information.
+
+    Key can be either "archive" (for per-archive data) or "file" (for per-file data) in the result.
+    """
+    result = {}
+    for section in sections.values():
+        for s in section["sources"]:
+            if not s[key] in result:
+                result[s[key]] = {}
+            archive = result[s[key]]
+            if not section["name"] in archive:
+                archive[section["name"]] = 0
+            archive[section["name"]] += s["size"]
+    return result
+def sizes_overall(sections):
+    """ Takes a dict of sections (from load_sections) and returns
+    a dict keyed by 'key' with aggregate output size information.
+
+    Key can be either "archive" (for per-archive data) or "file" (for per-file data) in the result.
+    """
+    result = {}
+    for section in sections.values():
+        result[section["name"]] = 0
+        for s in section["sources"]:
+            result[section["name"]] += s["size"]
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser("idf_size - a tool to print IDF elf file sizes")
+
+    parser.add_argument(
+        '--toolchain-prefix',
+        help="Triplet prefix to add before objdump executable",
+        default=DEFAULT_TOOLCHAIN_PREFIX)
+
+    parser.add_argument(
+        'map_file', help='MAP file produced by linker',
+        type=argparse.FileType('r'))
+
+    parser.add_argument(
+        '--archives', help='Print per-archive sizes', action='store_true')
+
+    parser.add_argument(
+        '--archive_details', help='Print detailed symbols per archive')
+
+    parser.add_argument(
+        '--files', help='Print per-file sizes', action='store_true')
+
+    args = parser.parse_args()
+
+    memory_config, sections = load_map_data(args.map_file)
+
+    print_summary(memory_config, sections)
+
+    if args.archives:
+        print("Per-archive contributions to ELF file:")
+        print_detailed_sizes(sections, "archive", "Archive File")
+    if args.files:
+        print("Per-file contributions to ELF file:")
+        print_detailed_sizes(sections, "file", "Object File")
+    if args.archive_details:
+        print("Symbols within the archive:", args.archive_details, "(Not all symbols may be reported)")
+        print_archive_symbols(sections, args.archive_details)
+
+
+def print_summary(memory_config, sections):
+    def get_size(section):
+        try:
+            return sections[section]["size"]
+        except KeyError:
+            print("No Such Section %s " % section)
+            return 0
+
+    # if linker script changes, these need to change
+    total_dram = memory_config["dram0_0_seg"]["length"]
+    total_iram = memory_config["iram1_0_seg"]["length"]
+    total_flash = memory_config["irom0_0_seg"]["length"]
+
+    # Snippet from one of datasheets:
+    #   "
+    #   ESP8266 features 160 Kbytes of RAM, of which iRAM is 64 KB and dRAM is 96KB
+    #   (dRAM: 80 KB for SDK+HEAP, 16 KB for ROM). The iRAM is further segmented into two
+    #   blocks. A 32 KB iRAM block stores code marked with IRAM_ATTR and the other 32 KB
+    #   block is used to cache code from flash, i.e. code marked with ICACHE_FLASH_ATTR. 
+    #   "
+
+    # dram:
+    #       .data .bss .roadata and heap
+    #       -
+    # iram:
+    #       .text .lit4
+    #       -functions intended for fast execution go here
+    # irom: 
+    #       irom0.text      
+    #       -external flash. Most of code goes here
+    #
+    # Total size of RAM == 160 kB
+    # 96 kB goes for dram
+    # 64 kB goes for (iram + cache)
+    #   cache is used to copy function from external flash into, before function execution
+    # some info avaliable at components/esp8266/ld/esp8266.ld and components/esp8266/ld/esp8266.common.ld
+
+    # some kind of summary form esp8266.common.ld
+
+    #   .text : ALIGN(4)
+    #   {
+    #   } >iram1_0_seg :iram1_0_phdr
+
+    #   .data : ALIGN(4)
+    #   {
+    #   } >dram0_0_seg :dram0_0_phdr
+
+    #   .rodata : ALIGN(4)
+    #   {
+    #   } >dram0_0_seg :dram0_0_phdr
+
+    #   .UserExceptionVector.literal : AT(LOADADDR(.rodata) + (ADDR(.UserExceptionVector.literal) - ADDR(.rodata))) ALIGN(4)
+    #   {
+    #   } >dram0_0_seg :dram0_0_phdr
+
+    #   .bss ALIGN(8) (NOLOAD) : ALIGN(4)
+    #   {
+    #   } >dram0_0_seg :dram0_0_bss_phdr
+
+    #   .irom0.text : ALIGN(4)
+    #   {
+    #   } >irom0_0_seg :irom0_0_phdr
+
+    #   .lit4 : ALIGN(4)
+    #   {
+    #   } >iram1_0_seg :iram1_0_phdr
+
+    # Print all sections info:
+    # for section, val in sections.iteritems():
+    #     if not section.startswith(".debug"):
+    #         print("Section: %20s: %s" % (section, val["size"]))
+
+    print("Summary: ")
+
+    used_data = get_size(".data")
+    used_bss = get_size(".bss")
+    used_rodata = get_size(".rodata")
+    used_dram = used_data + used_bss + used_rodata
+
+    print("Used static DRAM: %7d bytes (%7d available, %.1f%% used) Total: %3d kB" %
+          (used_dram, total_dram - used_dram,
+           100.0 * used_dram / total_dram, total_dram / 1024))
+    print("    DRAM .data    size: %7d bytes" % used_data)
+    print("    DRAM .bss     size: %7d bytes" % used_bss)
+    print("    DRAM .rodata  size: %7d bytes" % used_rodata)
+
+
+    used_iram = get_size(".text")
+    print("Used static IRAM: %7d bytes (%7d available, %.1f%% used) Total: %3d kB" %
+          (used_iram, total_iram - used_iram,
+           100.0 * used_iram / total_iram, total_iram / 1024))
+    print("    Cache size (IRAM + cache = 64 kB. Distribution can be modified):   %3d kB" % (64 -total_iram / 1024))
+
+    flash_code = get_size(".irom0.text")
+
+    print("Used Flash: %7d bytes (%7d available, %.1f%% used)       Total: %3d kB" %
+          (flash_code, total_flash - flash_code,
+           100.0 * flash_code / total_flash, total_flash / 1024))
+
+def print_detailed_sizes(sections, key, header):
+
+    sizes = sizes_by_key(sections, key)
+
+    headings = (header,
+                "DRAM .data",
+                "& .bss",
+                "& rodata",
+                "IRAM",
+                "Flash code",
+                "Total")
+    print("%24s %10s %6s %6s %10s %8s %7s" % headings)
+    result = {}
+    for k in sizes:
+        v = sizes[k]
+        result[k] = {}
+        result[k]["data"] = v.get(".data", 0)
+        result[k]["bss"] = v.get(".bss", 0)
+        result[k]["rodata"] = v.get(".rodata", 0)
+        result[k]["iram"] = v.get(".text",0)
+        result[k]["flash_text"] = v.get(".irom0.text", 0)
+        result[k]["total"] = sum(result[k].values())
+
+    def return_total_size(elem):
+        val = elem[1]
+        return val["total"]
+
+    def return_header(elem):
+        return elem[0]
+    s = sorted(list(result.items()), key=return_header)
+    # do a secondary sort in order to have consistent order (for diff-ing the output)
+    for k,v in sorted(s, key=return_total_size, reverse=True):
+        if ":" in k:  # print subheadings for key of format archive:file
+            sh,k = k.split(":")
+        print("%24s %10d %6d %6d %10d %8d %7d" % (k[:24],
+                                                  v["data"],
+                                                  v["bss"],
+                                                  v["rodata"],
+                                                  v["iram"],
+                                                  v["flash_text"],
+                                                  v["total"]))
+
+
+def print_archive_symbols(sections, archive):
+    interested_sections = [".data", ".bss", ".text", ".vectors", ".irom0.text", ".rodata"]
+    result = {}
+    for t in interested_sections:
+        result[t] = {}
+    for section in sections.values():
+        section_name = section["name"]
+        if section_name not in interested_sections:
+            continue
+        for s in section["sources"]:
+            if archive != s["archive"]:
+                continue
+            s["sym_name"] = re.sub("(.text.|.literal.|.data.|.bss.|.rodata.)", "", s["sym_name"])
+            result[section_name][s["sym_name"]] = result[section_name].get(s["sym_name"], 0) + s["size"]
+    for t in interested_sections:
+        print("\nSymbols from section:", t)
+        section_total = 0
+        s = sorted(list(result[t].items()), key=lambda k_v: k_v[0])
+        # do a secondary sort in order to have consistent order (for diff-ing the output)
+        for key,val in sorted(s, key=lambda k_v: k_v[1], reverse=True):
+            print(("%s(%d)" % (key.replace(t + ".", ""), val)), end=' ')
+            section_total += val
+        print("\nSection total:",section_total)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds `idf_size` tool for esp8266.
It is not more than slightly modified tool from esp-idf.

PR resolves this issue: #261 
`make size`, `make size-components`, `make size-files` and `make size-symbols` functionality is tested.