### PR TITLE
MAX_REQ_BODY_LEN in protocomm_httpd.c fixed and too low

### DIFF
--- a/components/protocomm/src/transports/protocomm_httpd.c
+++ b/components/protocomm/src/transports/protocomm_httpd.c
@@ -29,8 +29,6 @@ static protocomm_t *pc_httpd; /* The global protocomm instance for HTTPD */
 static bool pc_ext_httpd_handle_provided = false;
 static uint32_t session_id = PROTOCOMM_NO_SESSION_ID;
 
-#define MAX_REQ_BODY_LEN 4096
-
 static esp_err_t common_post_handler(httpd_req_t *req)
 {
     esp_err_t ret;
@@ -73,8 +71,8 @@ static esp_err_t common_post_handler(httpd_req_t *req)
         ESP_LOGE(TAG, "Content length not found");
         ret = ESP_FAIL;
         goto out;
-    } else if (req->content_len > MAX_REQ_BODY_LEN) {
-        ESP_LOGE(TAG, "Request content length should be less than 4kb");
+    } else if (req->content_len > CONFIG_MAX_REQ_BODY_LEN) {
+        ESP_LOGE(TAG, "Request content length should be less than %d bytes", CONFIG_MAX_REQ_BODY_LEN);
         ret = ESP_FAIL;
         goto out;
     }

--- a/components/wifi_provisioning/Kconfig
+++ b/components/wifi_provisioning/Kconfig
@@ -8,4 +8,12 @@ config ENABLE_UNIFIED_PROVISIONING
     select MBEDTLS_ECP_C
     help
         This enables Unified Provisioning feature along with required components like Wifi-Provisioning, Protocomm and their mbedtls dependencies.
+
+config MAX_REQ_BODY_LEN
+    int "Maximum body len of protocomm request"
+    default 4192
+    depends on ENABLE_UNIFIED_PROVISIONING
+    help
+       Size (in bytes) of the protocomm request body.
+
 endmenu


### PR DESCRIPTION
In provisioning is possible to send more data than wifi related items (In my case MQTT certificates) and 4k is very low.
But the maximum value of data managed is staticaly defined.
This is a problem because compel user to modify SDK.