### PR TITLE
Add missing cmake file required to run "make flash". (GIT8266O-246)

### DIFF
--- a/components/esptool_py/run_esptool.cmake
+++ b/components/esptool_py/run_esptool.cmake
@@ -1,0 +1,46 @@
+# A CMake script to run esptool commands from within ninja or make
+# or another cmake-based build runner
+#
+# (Needed to expand environment variables, for backwards compatibility.)
+#
+# It is recommended to NOT USE this CMake script if you have the option of
+# running esptool.py directly. This script exists only for use inside CMake builds.
+#
+cmake_minimum_required(VERSION 3.5)
+
+if(NOT IDF_PATH OR NOT ESPTOOLPY OR NOT ESPTOOL_ARGS OR NOT ESPTOOL_WORKING_DIR)
+    message(FATAL_ERROR "IDF_PATH, ESPTOOLPY, ESPTOOL_ARGS, and ESPTOOL_WORKING_DIR must "
+        "be specified on the CMake command line. For direct esptool execution, it is "
+        "strongly recommended to run esptool.py directly.")
+endif()
+
+# Note: we can't expand these environment variables in the main IDF CMake build,
+# because we want to expand them at flashing time not at CMake runtime (so they can change
+# without needing a CMake re-run)
+set(ESPPORT $ENV{ESPPORT})
+if(NOT ESPPORT)
+    message("Note: esptool.py will search for a serial port. To specify a port, set the ESPPORT environment variable.")
+else()
+    set(port_arg "-p ${ESPPORT}")
+endif()
+
+set(ESPBAUD $ENV{ESPBAUD})
+if(NOT ESPBAUD)
+    message("Note: Using default baud rate 460800. To modify, set ESPBAUD environment variable.")
+    set(ESPBAUD 460800)
+endif()
+
+include("${IDF_PATH}/tools/cmake/utilities.cmake")
+
+set(cmd "${ESPTOOLPY} ${port_arg} -b ${ESPBAUD} ${ESPTOOL_ARGS}")
+spaces2list(cmd)
+
+execute_process(COMMAND ${cmd}
+    WORKING_DIRECTORY "${ESPTOOL_WORKING_DIR}"
+    RESULT_VARIABLE result
+    )
+
+if(${result})
+    # No way to have CMake silently fail, unfortunately
+    message(FATAL_ERROR "esptool.py failed")
+endif()


### PR DESCRIPTION
It's a copy of **esp-idf** cmake file. Each project, which is building with cmake, needs to include this file to make "make flash".

`CMake Error: Error processing file: run_esptool.cmake
CMakeFiles/flash.dir/build.make:57: recipe for target 'CMakeFiles/flash' failed
make[3]: *** [CMakeFiles/flash] Error 1
CMakeFiles/Makefile2:159: recipe for target 'CMakeFiles/flash.dir/all' failed
make[2]: *** [CMakeFiles/flash.dir/all] Error 2
CMakeFiles/Makefile2:166: recipe for target 'CMakeFiles/flash.dir/rule' failed
make[1]: *** [CMakeFiles/flash.dir/rule] Error 2
Makefile:144: recipe for target 'flash' failed
`