### PR TITLE
Changed default esp32 toolchain prefix to esp8266 (GIT8266O-284)

### DIFF
--- a/tools/idf_monitor.py
+++ b/tools/idf_monitor.py
@@ -96,10 +96,9 @@ TAG_SERIAL_FLUSH = 2
 # regex matches an potential PC value (0x4xxxxxxx)
 MATCH_PCADDR = re.compile(r'0x4[0-9a-f]{7}', re.IGNORECASE)
 
-DEFAULT_TOOLCHAIN_PREFIX = "xtensa-esp32-elf-"
+DEFAULT_TOOLCHAIN_PREFIX = "xtensa-lx106-elf-"
 
 DEFAULT_PRINT_FILTER = ""
-
 
 class StoppableThread(object):
     """


### PR DESCRIPTION
The monitor cannot be invoked from a manually triggered cmake build 