### PR TITLE
[PATCH] Include default algorithm on Digest authorization

### DIFF
--- a/components/esp_http_client/lib/http_auth.c
+++ b/components/esp_http_client/lib/http_auth.c
@@ -81,6 +81,10 @@ char *http_auth_digest(const char *username, const char *password, esp_http_auth
         return NULL;
     }
 
+    if (auth_data->algorithm == NULL) {
+        auth_data->algorithm = "md5";
+    }
+
     ha1 = calloc(1, MD5_MAX_LEN);
     HTTP_MEM_CHECK(TAG, ha1, goto _digest_exit);
 


### PR DESCRIPTION
This PR fixes a problem that I'm having to authenticate with a server using the HTTP Digest authentication method. The server doesn't set the algorithm property on the `Authentication` header of the request, making the ESP crash while using the `esp_http_client` component to make requests. The crash happens on the check for the algorithm md5-sess on line 98 as the value is NULL at the time of the check.

According to [RFC7616](https://tools.ietf.org/html/rfc7616#page-7) the algorithm field should be assumed to be "MD5" if is not present on the `Authentication` header sent by the client.