### PR TITLE
Update pwm.c

### DIFF
--- a/components/esp8266/driver/pwm.c
+++ b/components/esp8266/driver/pwm.c
@@ -560,7 +560,7 @@ esp_err_t pwm_init(uint32_t period, uint32_t *duties, uint8_t channel_num, const
 
     for (i = 0; i < channel_num; i++) {
         pwm_obj->pwm_info[i].io_num =  pin_num[i];
-        pwm_obj->gpio_bit_mask |= (0x1 << pin_num[i]);
+        pwm_obj->gpio_bit_mask |= ( (uint32_t) 1 << pin_num[i]);
     }
     gpio_config_t io_conf;
     io_conf.intr_type = GPIO_INTR_DISABLE;


### PR DESCRIPTION
Got a "GPIO pin mask" error message when trying to use GPIO16 (NodeMCU 1.0 onboard LED) with PWM (no other GPIO in the PWM).
When using PWM with GPIO16 and other GPIOs, I don't have the error message, however I cannot see any message related to the GPIO16 initialization (messages only for the initialization of the other GPIOs).
So, I'm thiking the left shift is restricted to short int (0x01), so shift by 16 (GPIO16) will result to 0. Using uint32_t should solve the issue...
(no yet tested...)