### PR TITLE
httpd_stop() can only work if lwip loopback is enabled.

### DIFF
--- a/components/esp_http_server/src/httpd_main.c
+++ b/components/esp_http_server/src/httpd_main.c
@@ -380,6 +380,13 @@ esp_err_t httpd_stop(httpd_handle_t handle)
         return ESP_ERR_INVALID_ARG;
     }
 
+#ifndef CONFIG_LWIP_NETIF_LOOPBACK
+    ESP_LOGE(TAG, LOG_FMT("Can not stop httpd server if lwip loopback is not enabled!"));
+    ESP_LOGE(TAG, LOG_FMT("Set LWIP_LOOPBACK_MAX_PBUFS=1 & LWIP_NETIF_LOOPBACK=y"));
+    /* We don't return to loop endlessly in the while loop below
+       and be sure the user understands the problem */
+#endif
+
     struct httpd_ctrl_data msg;
     memset(&msg, 0, sizeof(msg));
     msg.hc_msg = HTTPD_CTRL_SHUTDOWN;


### PR DESCRIPTION
To avoid developer to search for half a day why httpd_stop() blocks when called, an error log message is added which will be printed in case lwip loopback is not enabled.
