### PR TITLE
utils: sha512: fix memory corruption

### DIFF
--- a/components/util/src/sha512.c
+++ b/components/util/src/sha512.c
@@ -256,7 +256,8 @@ int esp_sha384_finish(esp_sha384_t *ctx, void *dest)
 
     ctx->buffer[used++] = 0x80;
 
-    memset(ctx->buffer + used, 0, 112 - used);
+    if (used < 112)
+        memset(ctx->buffer + used, 0, 112 - used);
 
     if (used > 112) {
         esp_sha512_transform(ctx, ctx->buffer);


### PR DESCRIPTION
The esp_sha384_finish() function retrieves the number of used bytes in the sha384 context and sets to zero the unused bytes in the buffer, up to the 112-byte offset, by calling memset() with (112 - used) as size argument. If the number of used bytes is more than 112, the size argument is converted from a negative value to an unsigned value, which causes memset() to overrun the buffer and corrupt the memory outside the buffer.
This commit fixes the above issue by inserting a conditional clause so that memset() is only called if the number of used bytes is less than 112.