### PR TITLE
utils: sha512: write only 48 bytes if hash type is SHA384

### DIFF
--- a/components/util/include/esp_sha.h
+++ b/components/util/include/esp_sha.h
@@ -38,6 +38,7 @@ typedef struct {
     uint64_t        total[2];
     uint64_t        state[8];
     uint8_t         buffer[128];
+    int             is384;
 } esp_sha512_t;
 
 typedef esp_sha256_t esp_sha224_t;

--- a/components/util/src/sha512.c
+++ b/components/util/src/sha512.c
@@ -171,6 +171,8 @@ int esp_sha512_init(esp_sha512_t *ctx)
     ctx->state[6] = UL64(0x1F83D9ABFB41BD6B);
     ctx->state[7] = UL64(0x5BE0CD19137E2179);
 
+    ctx->is384 = 0;
+
     return 0;   
 }
 
@@ -189,6 +191,8 @@ int esp_sha384_init(esp_sha384_t *ctx)
     ctx->state[5] = UL64(0x8EB44A8768581511);
     ctx->state[6] = UL64(0xDB0C2E0D64F98FA7);
     ctx->state[7] = UL64(0x47B5481DBEFA4FA4);
+
+    ctx->is384 = 1;
 
     return 0;   
 }
@@ -290,8 +294,10 @@ int esp_sha512_finish(esp_sha512_t *ctx, void *dest)
 
     esp_sha384_finish(ctx, dest);
 
-    PUT_UINT64_BE(ctx->state[6], output, 48);
-    PUT_UINT64_BE(ctx->state[7], output, 56);
+    if (!ctx->is384) {
+        PUT_UINT64_BE(ctx->state[6], output, 48);
+        PUT_UINT64_BE(ctx->state[7], output, 56);
+    }
 
     return 0;
 }


### PR DESCRIPTION
The esp_sha512_finish() function writes the calculated hash to the dest buffer. Since this function is used for both SHA512 and SHA384 hash types, it should check which type is being used at a given call, and write the corresponding number of bytes (either 48 or 64) accordingly, otherwise if it unconditionally writes 64 bytes, when called for an SHA384 hash it will write past the length of the
destination buffer.
This commit fixes the above issue by adding a new struct member to esp_sha512_t which indicates whether SHA384 or SHA512 is being used, and adding a check on the value of the struct member in esp_sha512_finish() in order to write the correct number of bytes.