### PR TITLE
updated index.rst

### DIFF
--- a/docs/en/get-started/index.rst
+++ b/docs/en/get-started/index.rst
@@ -129,7 +129,7 @@ Install the Required Python Packages
 
 Python packages required by ESP8266\_RTOS\_SDK are located in the ``$IDF_PATH/requirements.txt`` file. You can install them by running::
 
-    python -m pip install --user -r $IDF_PATH/requirements.txt
+    python -m pip install --user -r docs/requirements.txt
 
 .. note::
 


### PR DESCRIPTION
In documentation, path of requirements.txt is wrong as in ESP8266_RTOS_SDK the mentioned file is in /docs/ folder.
Fixing the doc because users might get confused by it.