### PR TITLE
Fix for a possible race condition in uart_tx_all when it is used heavily

### DIFF
--- a/components/esp8266/driver/uart.c
+++ b/components/esp8266/driver/uart.c
@@ -763,6 +763,12 @@ static int uart_tx_all(uart_port_t uart_num, const char *src, size_t size)
         xSemaphoreGive(p_uart_obj[uart_num]->tx_done_sem);
     }
     xSemaphoreGive(p_uart_obj[uart_num]->tx_mux);
+
+    // If we don't wait it is possible to get into a race condition
+    // when the fifo tx interrupt is triggered late and another set of data
+    // gets stuck in the tx buffer until a third uart_tx_all pushes it through
+    uart_wait_tx_done(uart_num, (portTickType)portMAX_DELAY);
+
     return original_size;
 }
 


### PR DESCRIPTION
This condition triggers on the live SDK running on a fleet of ESP-12E with esp-at firmware. Using AT+CWLAP when a lot of access points are present triggers heavy usage of at_port_print that in the end calls uart_tx_all. Eventually some of the lines get stuck but are then safely pushed through when something else (say, AT echo, other task doing uart_tx_all or just enabling the TX FIFO empty interrupt in a timer-based loop) enables the TX FIFO empty interrupt.

This seems to be caused by the fact that the interrupt handler uart_rx_intr_handler_default disables the TX FIFO empty interrupt condition when p_uart->tx_len_tot becomes 0 but that is the case for the current "set" of ringbuffer items. It doesn't (and shouldn't due to the limited timing) check if there is another uart_tx_data_t waining in the ring buffer. This can be prevented if uart_tx_all stalls until the current tx buffer falls through the ring buffer and before any new one is pushed into the ring buffer. Otherwise the subsequent call to uart_tx_all can push the data into the ring buffer but never actually initiate the next interrupt causing the data to be stuck in the ring buffer for an undefined amount of time.