### PR TITLE
sovle the bug of ' IP_EVENT_AP_STAIPASSIGNED'

### DIFF
--- a/components/esp_event/event_send_compat.inc
+++ b/components/esp_event/event_send_compat.inc
@@ -91,7 +91,8 @@ esp_err_t esp_event_send_to_default_loop(system_event_t *event)
         HANDLE_SYS_EVENT_ARG(IP, STA_GOT_IP, got_ip);
         HANDLE_SYS_EVENT(IP, STA_LOST_IP);
         HANDLE_SYS_EVENT_ARG(IP, GOT_IP6, got_ip6);
-        HANDLE_SYS_EVENT(IP, AP_STAIPASSIGNED);
+        //HANDLE_SYS_EVENT(IP, AP_STAIPASSIGNED);
+        HANDLE_SYS_EVENT_ARG(IP, AP_STAIPASSIGNED, ap_staipassigned);
         default:
             return ESP_ERR_NOT_SUPPORTED;
     }


### PR DESCRIPTION
Modify `HANDLE_SYS_EVENT(IP, AP_STAIPASSIGNED); `to `HANDLE_SYS_EVENT_ARG(IP, AP_STAIPASSIGNED, ap_staipassigned);`.
Because it has returnable and essential data.