### PR TITLE
Fix several errors GCC 10 detects on build (GIT8266O-496)

### DIFF
--- a/components/bootloader_support/include/esp_image_format.h
+++ b/components/bootloader_support/include/esp_image_format.h
@@ -37,12 +37,12 @@ typedef enum {
 } esp_image_spi_mode_t;
 
 /* SPI flash clock frequency */
-enum {
+typedef enum {
     ESP_IMAGE_SPI_SPEED_40M,
     ESP_IMAGE_SPI_SPEED_26M,
     ESP_IMAGE_SPI_SPEED_20M,
     ESP_IMAGE_SPI_SPEED_80M = 0xF
-} esp_image_spi_freq_t;
+};
 
 #ifdef CONFIG_IDF_TARGET_ESP32
 /* Supported SPI flash sizes */

--- a/components/newlib/newlib/include/sys/reent.h
+++ b/components/newlib/newlib/include/sys/reent.h
@@ -402,7 +402,7 @@ struct _reent
   char *_asctime_buf;
 
   /* signal info */
-  void (**(_sig_func))(int);
+  void (**_sig_func)(int);
 
 # ifndef _REENT_GLOBAL_ATEXIT
   /* atexit stuff */

--- a/components/spi_flash/src/partition.c
+++ b/components/spi_flash/src/partition.c
@@ -205,7 +205,7 @@ static esp_err_t load_partitions()
 #endif
 
         // it->label may not be zero-terminated
-        strncpy(item->info.label, (const char*) it->label, sizeof(it->label));
+        strncpy(item->info.label, (const char*) it->label, sizeof(item->info.label));
         item->info.label[sizeof(it->label)] = 0;
         // add it to the list
         if (last == NULL) {

--- a/components/spiffs/esp_spiffs.c
+++ b/components/spiffs/esp_spiffs.c
@@ -654,7 +654,7 @@ static int vfs_spiffs_readdir_r(void* ctx, DIR* pdir, struct dirent* entry,
     }
     entry->d_ino = 0;
     entry->d_type = out.type;
-    snprintf(entry->d_name, SPIFFS_OBJ_NAME_LEN, "%s", item_name);
+    snprintf(entry->d_name, sizeof(entry->d_name), "%s", item_name);
     dir->offset++;
     *out_dirent = entry;
     return 0;

--- a/components/wpa_supplicant/src/rsn_supp/wpa.c
+++ b/components/wpa_supplicant/src/rsn_supp/wpa.c
@@ -2004,9 +2004,7 @@ void ICACHE_FLASH_ATTR wpa_register(char* payload, WPA_SEND_FUNC snd_func,
     if (sm->pmksa == NULL) {
         wpa_printf(MSG_ERROR,
                 "RSN: PMKSA cache initialization failed");
-        return false;
     }
-    return true;
 }
 
 void wpa_set_profile(u32 wpa_proto, u8 auth_mode)

--- a/components/wpa_supplicant/src/wps/wps_i.h
+++ b/components/wpa_supplicant/src/wps/wps_i.h
@@ -154,7 +154,7 @@ typedef struct {
 	esp_factory_information_t factory_info;
 }esp_wps_config_t;
 
-wps_crypto_funcs_t wps_crypto_funcs;
+extern wps_crypto_funcs_t wps_crypto_funcs;
 
 /* wps_common.c */
 void wps_kdf(const u8 *key, const u8 *label_prefix, size_t label_prefix_len,


### PR DESCRIPTION
A few minor errors were discovered while using the GCC 10.1 compiler we
intend to use on the next major release of ESP8266 Arduino.  Fix them

* In WPA supplicant, there is a void function() returning a boolean.

* Several headers actually define global variables instead of just the
extern reference.

* A Newlib header has an unneeded set of parenthesis.

* The size of strncpy() destinations was off in a couple spots.

Other than the strncpy() destination size change the others are very
minor.