### PR TITLE
openssl command requires winpty on windows

### DIFF
--- a/examples/system/ota/simple_ota_example/README.md
+++ b/examples/system/ota/simple_ota_example/README.md
@@ -56,6 +56,8 @@ openssl req -x509 -newkey rsa:2048 -keyout ca_key.pem -out ca_cert.pem -days 365
 
 ```
 
+*NOTE: If using Windows, add `winpty` to the beginning of your `openssl` or else it cannot accept input from terminal.*
+
 Copy the certificate to `server_certs` directory inside OTA example directory:
 
 ```


### PR DESCRIPTION
On Window, running these commands with mingw as per https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/windows-setup.html , the `openssl` command must be run with `winpty`, or else it hangs. This is because openssl requires input from terminal.
See https://stackoverflow.com/questions/9450120/openssl-hangs-and-does-not-exit/45732888 and https://www.esp32.com/viewtopic.php?t=9521 .