### PR TITLE
fix incremental build of "make ota" (GIT8266O-562)

### DIFF
--- a/components/esp8266/Makefile.projbuild
+++ b/components/esp8266/Makefile.projbuild
@@ -130,6 +130,7 @@ ifdef __COMBILE_OTA_BIN
 	@rm -f ./build/esp8266/esp8266_out.ld
 	@export CFLAGS= && export CXXFLAGS= && make $(APP_BIN) APP_OFFSET=$(APP2_OFFSET) APP_SIZE=$(APP2_SIZE)
 endif
+	@rm -f build/esp8266/esp8266.project.ld
 	@cp $(RAW_BIN) $(OTA2_BIN)
 	@echo [GEN] $(OTA2_BIN)
 


### PR DESCRIPTION
The current "make ota" second time without cleaning the whole project
will result in bad binary files. Somehow "make ota" always rebuild
the two binary files even without any change to source code. During
thisprocess, the "elf" file is rebuilt twice for app1 and app2.

However the"esp8266.project.ld" was not regenerated for the app1 if
it already exists. 

This caused the second time running the "make ota", app1.bin was linked
with the wrong "esp8266.project.ld". There for, incremental build of
ota always produces the bad bin.

That is the likely the cause of github issue:
https://github.com/espressif/ESP8266_RTOS_SDK/issues/854
https://github.com/espressif/ESP8266_RTOS_SDK/issues/745

I have verified that removing the "esp8266.project.ld" before the second
"make ota" can produce the correct image.

The short term work around is to always remove "esp8266.project.ld"
after the app2 has been built.

This change will make the second time "make ota" work without cleaning the
whole project.

Of course the long term fix is to properly specify the dependency of
the ota binary image.