### PR TITLE
Allow "make ota" work with V=1

### DIFF
--- a/components/esp8266/Makefile.projbuild
+++ b/components/esp8266/Makefile.projbuild
@@ -51,7 +51,7 @@ $(PHY_INIT_DATA_BIN): $(PHY_INIT_DATA_OBJ)
 phy_init_data: $(PHY_INIT_DATA_BIN)
 
 phy_init_data-flash: $(BUILD_DIR_BASE)/phy_init_data.bin
-	@echo "Flashing PHY init data..."
+	$(summary) "Flashing PHY init data..."
 	$(PHY_INIT_DATA_FLASH_CMD)
 
 phy_init_data-clean:
@@ -108,56 +108,56 @@ endif
 
 app2: all
 ifdef CONFIG_ESPTOOLPY_FLASHSIZE_1MB
-	@rm -f ./build/esp8266/esp8266_out.ld
-	@export CFLAGS= && export CXXFLAGS= && make APP_OFFSET=$(APP2_OFFSET) APP_SIZE=$(APP2_SIZE)
+	rm -f ./build/esp8266/esp8266_out.ld
+	export CFLAGS= && export CXXFLAGS= && make APP_OFFSET=$(APP2_OFFSET) APP_SIZE=$(APP2_SIZE)
 endif
-	@echo "To flash all build output, run 'make flash' or:"
-	@echo $(ESPTOOLPY_WRITE_FLASH) $(APP2_OFFSET) $(APP_BIN)
+	echo "To flash all build output, run 'make flash' or:"
+	echo $(ESPTOOLPY_WRITE_FLASH) $(APP2_OFFSET) $(APP_BIN)
 
 app2-flash: app2
-	@$(ESPTOOLPY_WRITE_FLASH) $(APP2_OFFSET) $(APP_BIN)
+	$(ESPTOOLPY_WRITE_FLASH) $(APP2_OFFSET) $(APP_BIN)
 
 app2-flash-all: app2
-	@$(ESPTOOLPY_WRITE_FLASH) $(patsubst $(APP_OFFSET),$(APP2_OFFSET),$(ESPTOOL_ALL_FLASH_ARGS))
+	$(ESPTOOLPY_WRITE_FLASH) $(patsubst $(APP_OFFSET),$(APP2_OFFSET),$(ESPTOOL_ALL_FLASH_ARGS))
 
 $(OTA1_BIN): all_binaries
-	@cp $(RAW_BIN) $(RAW_BIN).old
-	@cp $(RAW_BIN) $(OTA1_BIN)
-	@echo [GEN] $(OTA1_BIN)
+	cp $(RAW_BIN) $(RAW_BIN).old
+	cp $(RAW_BIN) $(OTA1_BIN)
+	$(summary) [GEN] $(OTA1_BIN)
 
 $(OTA2_BIN): $(OTA1_BIN)
 ifdef __COMBILE_OTA_BIN
-	@rm -f ./build/esp8266/esp8266_out.ld
-	@export CFLAGS= && export CXXFLAGS= && make $(APP_BIN) APP_OFFSET=$(APP2_OFFSET) APP_SIZE=$(APP2_SIZE)
+	rm -f ./build/esp8266/esp8266_out.ld
+	export CFLAGS= && export CXXFLAGS= && make $(APP_BIN) APP_OFFSET=$(APP2_OFFSET) APP_SIZE=$(APP2_SIZE)
 endif
-	@cp $(RAW_BIN) $(OTA2_BIN)
-	@echo [GEN] $(OTA2_BIN)
+	cp $(RAW_BIN) $(OTA2_BIN)
+	$(summary) [GEN] $(OTA2_BIN)
 
 $(OTA_BIN): $(OTA2_BIN)
-	@cp $(OTA1_BIN) $(OTA_BIN)
+	cp $(OTA1_BIN) $(OTA_BIN)
 ifdef __COMBILE_OTA_BIN
-	@cat $(OTA2_BIN) >> $(OTA_BIN)
-	@cp $(OTA1_BIN) $(RAW_BIN)
+	cat $(OTA2_BIN) >> $(OTA_BIN)
+	cp $(OTA1_BIN) $(RAW_BIN)
 endif
-	@echo [GEN] $(OTA_BIN)
+	$(summary) [GEN] $(OTA_BIN)
 
 PYTHON ?= $(call dequote,$(CONFIG_PYTHON))
 
 ifdef CONFIG_ESP8266_OTA_FROM_OLD
 $(OTA_V2_TO_V3_BIN): all
-	@$(PYTHON) $(IDF_PATH)/tools/pack_fw.py --output $(OTA_V2_TO_V3_BIN) --app $(PROJECT_NAME).bin  pack3 $(ESPTOOL_ALL_FLASH_ARGS)
-	@echo [GEN] $(OTA_V2_TO_V3_BIN)
+	$(PYTHON) $(IDF_PATH)/tools/pack_fw.py --output $(OTA_V2_TO_V3_BIN) --app $(PROJECT_NAME).bin  pack3 $(ESPTOOL_ALL_FLASH_ARGS)
+	$(summary) [GEN] $(OTA_V2_TO_V3_BIN)
 endif
 
 ifdef CONFIG_ESP8266_OTA_FROM_OLD
 ota: $(OTA_V2_TO_V3_BIN)
 else
 ota: $(OTA_BIN)
-	@cp $(RAW_BIN).old $(RAW_BIN)
-	@rm $(RAW_BIN).old
+	cp $(RAW_BIN).old $(RAW_BIN)
+	rm $(RAW_BIN).old
 endif
 
 ota-clean:
-	@rm -f $(OTA_BIN) $(OTA1_BIN) $(OTA2_BIN) $(OTA_V2_TO_V3_BIN)
+	rm -f $(OTA_BIN) $(OTA1_BIN) $(OTA2_BIN) $(OTA_V2_TO_V3_BIN)
 
 clean: ota-clean


### PR DESCRIPTION
Using "@" will disable output of command regardless of V=1 set or not.
This change followes the rest of the build system convention of printing out
command if verbose is enabled.