### PR TITLE
Fix hw_timer inclusion error

### DIFF
--- a/components/esp8266/driver/hw_timer.c
+++ b/components/esp8266/driver/hw_timer.c
@@ -14,8 +14,6 @@
 
 
 #include <stdio.h>
-#include <stdbool.h>
-#include <stdint.h>
 
 #include "FreeRTOS.h"
 

--- a/components/esp8266/include/driver/hw_timer.h
+++ b/components/esp8266/include/driver/hw_timer.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "esp_err.h"
 


### PR DESCRIPTION
Hello there,  
There are lots of bool usage in the `hw_timer` header, but the `stdbool` isn't there, causing compilation errors.

This PR just move `stdbool` inclusion from `.c` to `.h`.
Also, remove `stdint` from the implementation since it hasn't been used anywhere apart from what is defined in `.h`.