### PR TITLE
fix(example): make s_connection_passwd 64 byte long (GIT8266O-574)

### DIFF
--- a/examples/common_components/protocol_examples_common/connect.c
+++ b/examples/common_components/protocol_examples_common/connect.c
@@ -39,7 +39,7 @@
 static EventGroupHandle_t s_connect_event_group;
 static ip4_addr_t s_ip_addr;
 static char s_connection_name[32] = CONFIG_EXAMPLE_WIFI_SSID;
-static char s_connection_passwd[32] = CONFIG_EXAMPLE_WIFI_PASSWORD;
+static char s_connection_passwd[64] = CONFIG_EXAMPLE_WIFI_PASSWORD;
 
 #ifdef CONFIG_EXAMPLE_CONNECT_IPV6
 static ip6_addr_t s_ipv6_addr;
@@ -110,7 +110,7 @@ static void start(void)
     wifi_config_t wifi_config = { 0 };
 
     strncpy((char *)&wifi_config.sta.ssid, s_connection_name, 32);
-    strncpy((char *)&wifi_config.sta.password, s_connection_passwd, 32);
+    strncpy((char *)&wifi_config.sta.password, s_connection_passwd, 64);
 
     ESP_LOGI(TAG, "Connecting to %s...", wifi_config.sta.ssid);
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));


### PR DESCRIPTION
This commit will use every byte available from wifi_config_t's
sta.password (which is 64 bytes long).