### PR TITLE
Add missing FreeRTOS header inclusion that cause compilation errors

### DIFF
--- a/components/esp8266/include/driver/uart.h
+++ b/components/esp8266/include/driver/uart.h
@@ -23,6 +23,7 @@ extern "C" {
 #include <stdbool.h>
 #include "esp_err.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
 #define UART_FIFO_LEN           (128)        /*!< Length of the hardware FIFO buffers */


### PR DESCRIPTION
Another missing header.
I've got
~~~text
In file included from /home/me/esp/ESP8266_RTOS_SDK/components/esp8266/include/driver/uart.h:25:0,
                 from main.c:1:
/home/me/esp/ESP8266_RTOS_SDK/components/freertos/include/freertos/queue.h:33:3: error: #error "include FreeRTOS.h" must appear in source files before "include queue.h"
~~~
Adding what suggested and the compilation passed.
This is because `queue.h` uses something that defines in `FreeRTOS.h`