### PR TITLE
fix(esp_http_server): break infinite select on bad socket

### DIFF
--- a/components/esp_http_server/src/httpd_sess.c
+++ b/components/esp_http_server/src/httpd_sess.c
@@ -193,7 +193,7 @@ void httpd_sess_set_descriptors(struct httpd_data *hd,
 /** Check if a FD is valid */
 static int fd_is_valid(int fd)
 {
-    return fcntl(fd, F_GETFD, 0) != -1 || errno != EBADF;
+    return fcntl(fd, F_GETFD, 0) != -1;
 }
 
 static inline uint64_t httpd_sess_get_lru_counter()


### PR DESCRIPTION
The `lwip_fcntl` implementation doesn't set `EBADF` on bad socket as should be, so don't rely on it.  
This patch break http server looping on `select` when socket closed unexpectedly.