### PR TITLE
fix(http server): don't leave socket in list if open failed

### DIFF
--- a/components/esp_http_server/src/httpd_sess.c
+++ b/components/esp_http_server/src/httpd_sess.c
@@ -78,7 +78,10 @@ esp_err_t httpd_sess_new(struct httpd_data *hd, int newfd)
             /* Call user-defined session opening function */
             if (hd->config.open_fn) {
                 esp_err_t ret = hd->config.open_fn(hd, hd->hd_sd[i].fd);
-                if (ret != ESP_OK) return ret;
+                if (ret != ESP_OK) {
+                    hd->hd_sd[i].fd = -1;
+                    return ret;
+                }
             }
             return ESP_OK;
         }


### PR DESCRIPTION
In case of `open_fn` failure the socket stay in the opening session list.

This behavior isn't expected by caller method `httpd_accept_conn` which closes the socket immediately after error returned.

Thus bad socket stays in the sessions list.