### PR TITLE
Fix for GPIO0/2/4/5 not being able to be used as inputs

### DIFF
--- a/components/esp8266/driver/gpio.c
+++ b/components/esp8266/driver/gpio.c
@@ -334,8 +334,8 @@ esp_err_t gpio_config(const gpio_config_t *gpio_cfg)
             // It should be noted that GPIO0, 2, 4, and 5 need to set the func register to 0,
             // and the other GPIO needs to be set to 3 so that IO can be GPIO function.
             if ((0x1 << io_num) & (GPIO_Pin_0 | GPIO_Pin_2 | GPIO_Pin_4 | GPIO_Pin_5)) {
-                pin_reg.rtc_pin.func_low_bit = 0;
-                pin_reg.rtc_pin.func_high_bit = 0;
+                pin_reg.func_low_bit = 0;
+                pin_reg.func_high_bit = 0;
             } else {
                 pin_reg.func_low_bit = 3;
                 pin_reg.func_high_bit = 0;


### PR DESCRIPTION
After migrating my project from Arduino to ESP SDK, I noticed that GPIO2 couldn't work as input anymore. I tried to upload the basic [GPIO example](https://github.com/espressif/ESP8266_RTOS_SDK/tree/master/examples/peripherals/gpio) with GPIO2 being the  input and it didn't work. After some investigating, it turned out that the GPIO driver [has a problem](https://github.com/espressif/ESP8266_RTOS_SDK/blob/b4b9763c8fab671a639c6fdecde20c7c18559857/components/esp8266/driver/gpio.c#L337-L338): it treats pins GPIO0/2/4/5 as RTC pins when setting the GPIO function bits, despite there being only RTC pin according to the ESP8266 pin list – RTC_GPIO0.

This is a fix for this problem.