### PR TITLE
fix time drift - fix esp_timer_get_time - exclude some unused from compile

### DIFF
--- a/components/freertos/port/esp8266/include/freertos/FreeRTOSConfig.h
+++ b/components/freertos/port/esp8266/include/freertos/FreeRTOSConfig.h
@@ -180,7 +180,12 @@ uint32_t esp_get_time(void);
 
 #endif /* CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS */
 
+#ifdef ESP_ENABLE_ESP_OS_TICKS
+/*see note in port.c*/
 #define traceINCREASE_TICK_COUNT(_ticks)    esp_increase_tick_cnt(_ticks)
+#else
+#define traceINCREASE_TICK_COUNT(_ticks)
+#endif
 
 #ifndef configIDLE_TASK_STACK_SIZE
 #define configIDLE_TASK_STACK_SIZE CONFIG_FREERTOS_IDLE_TASK_STACKSIZE

--- a/components/freertos/port/esp8266/include/freertos/portmacro.h
+++ b/components/freertos/port/esp8266/include/freertos/portmacro.h
@@ -200,7 +200,9 @@ uint32_t xPortGetTickRateHz(void);
 
 void _xt_enter_first_task(void);
 
+#ifdef ESP_ENABLE_ESP_OS_TICKS
 void esp_increase_tick_cnt(const TickType_t ticks);
+#endif
 
 /* API compatible with esp-idf  */
 #define xTaskCreatePinnedToCore(pvTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pvCreatedTask, tskNO_AFFINITY) \

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -60,17 +60,19 @@ static const char s_log_prefix[ESP_LOG_MAX] = {
 uint32_t IRAM_ATTR esp_log_early_timestamp()
 {
 #ifndef BOOTLOADER_BUILD
-    extern uint64_t g_esp_os_us;
+    //extern volatile uint64_t g_esp_os_us;
+	extern int64_t esp_timer_get_time(void);
     extern uint32_t g_esp_boot_ccount;
 
-    const uint32_t ticks_per_ms = g_esp_ticks_per_us * 1000;
-    const uint32_t ms = g_esp_os_us / 1000 + g_esp_boot_ccount / ((CRYSTAL_USED * 2) * 1000);
+    const uint32_t ms = esp_timer_get_time() / 1000 + g_esp_boot_ccount / ((CRYSTAL_USED * 2) * 1000);
+    return ms;
 #else
     const uint32_t ticks_per_ms = ((CRYSTAL_USED * 2) * 1000);
     const uint32_t ms = 0;
+    return soc_get_ccount() / ticks_per_ms + ms;
 #endif
 
-    return soc_get_ccount() / ticks_per_ms + ms;
+
 }
 
 #ifndef BOOTLOADER_BUILD


### PR DESCRIPTION
a portion of xPortSysTickHandle is rewritten to solve the time drift issue in:
https://github.com/espressif/ESP8266_RTOS_SDK/issues/1068#issue-840813328

Note:
- The main flow of the handler (performed when there is no occurred latency) runs with the better performance of (average) 150 clock cycles saved on each call.
- When recovering,  the manager further checks the evaluated values ​​(see loop) to make sure they work. This ensure against further latencies inside the handler due any nmi shot (of unknown lenght)
- Some parts are only required by a freertos compile option. The same build condition has been added to the handler to further save resources and cpu. The purpose of g_esp_os_cpu_clk is preserved.
- g_esp_os_ticks: seems no longer used by this sdk.  Applied a conditional exclusion to save resources. 
- esp_timer_get_time: an own interrupt protection has been added with an internally stored interrupt status. This also allows you to call the function from anywhere (even inside critical sections or interrupt handlers).
- xPortSysTickHandle contains a large comment in order to explain how it works to the reviewer. If so, feel free to take it off. 

This is my first pull request, so I would be grateful for any feedback.
Thank you.

