### PR TITLE
Added password length check and warning

### DIFF
--- a/examples/wifi/getting_started/softAP/main/softap_example_main.c
+++ b/examples/wifi/getting_started/softAP/main/softap_example_main.c
@@ -62,7 +62,10 @@ void wifi_init_softap()
             .authmode = WIFI_AUTH_WPA_WPA2_PSK
         },
     };
-    if (strlen(EXAMPLE_ESP_WIFI_PASS) == 0) {
+    if (strlen(EXAMPLE_ESP_WIFI_PASS)<8) {
+        if (strlen(EXAMPLE_ESP_WIFI_PASS)>0) {
+            ESP_LOGW(TAG, "WiFi AP password has to be at least 8 characters long, falling back to WIFI_AUTH_OPEN authmode.");
+        }
         wifi_config.ap.authmode = WIFI_AUTH_OPEN;
     }
 


### PR DESCRIPTION
Password less than 8 characters long in WPA2 mode will generate a panic without a readable reason code, so this check is necessary.