### PR TITLE
Pass IDF_PATH to sdkconfig.py (GIT8266O-663)

### DIFF
--- a/tools/cmake/ldgen.cmake
+++ b/tools/cmake/ldgen.cmake
@@ -58,7 +58,8 @@ function(__ldgen_process_template template output)
 
     add_custom_command(
         OUTPUT ${output}
-        COMMAND ${python} ${idf_path}/tools/ldgen/ldgen.py
+        COMMAND ${CMAKE_COMMAND} -E env "IDF_PATH=${IDF_PATH}"
+            ${python} ${idf_path}/tools/ldgen/ldgen.py
         --config    ${sdkconfig}
         --fragments "$<JOIN:${ldgen_fragment_files},\t>"
         --input     ${template}

--- a/tools/ldgen/sdkconfig.py
+++ b/tools/ldgen/sdkconfig.py
@@ -18,7 +18,13 @@ import os
 from pyparsing import Word, alphanums, printables, Combine, Literal, hexnums, quotedString, Optional, nums, removeQuotes, oneOf, Group, infixNotation, opAssoc
 
 import sys
-sys.path.insert(0, os.environ.get('IDF_PATH') + '/tools/kconfig_new')
+
+try:
+    idf_path = os.environ['IDF_PATH']
+except KeyError:
+    idf_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '../..'))
+sys.path.insert(0, idf_path + '/tools/kconfig_new')
+
 try:
     import kconfiglib
 except ImportError:

--- a/tools/ldgen/sdkconfig.py
+++ b/tools/ldgen/sdkconfig.py
@@ -18,12 +18,7 @@ import os
 from pyparsing import Word, alphanums, printables, Combine, Literal, hexnums, quotedString, Optional, nums, removeQuotes, oneOf, Group, infixNotation, opAssoc
 
 import sys
-
-try:
-    idf_path = os.environ['IDF_PATH']
-except KeyError:
-    idf_path = os.path.realpath(os.path.join(os.path.dirname(__file__), '../..'))
-sys.path.insert(0, idf_path + '/tools/kconfig_new')
+sys.path.insert(0, os.environ.get('IDF_PATH') + '/tools/kconfig_new')
 
 try:
     import kconfiglib

--- a/tools/ldgen/sdkconfig.py
+++ b/tools/ldgen/sdkconfig.py
@@ -19,7 +19,6 @@ from pyparsing import Word, alphanums, printables, Combine, Literal, hexnums, qu
 
 import sys
 sys.path.insert(0, os.environ.get('IDF_PATH') + '/tools/kconfig_new')
-
 try:
     import kconfiglib
 except ImportError:


### PR DESCRIPTION
### This pull request is fixing error, when IDF_PATH isn't set globally, but determined during build time in tools/cmake/idf.cmake:19

It allows to build SDK without setting IDF_PATH as system env. variable and avoid the following error:
```
  File "D:\ESP8266_RTOS_SDK\tools\ldgen\sdkconfig.py", line 27, in <module>
    sys.path.insert(0, os.environ.get('IDF_PATH') + '/tools/kconfig_new')
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

So, if IDF_PATH was set automatically by idf.cmake, need to pass it as env variable to child process.
