### PR TITLE
Ported URI wildcard matching functionality from ESP32 SDK (GIT8266O-681)

### DIFF
--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -49,6 +49,7 @@ initializer that should be kept in sync
         .global_transport_ctx_free_fn = NULL,           \
         .open_fn = NULL,                                \
         .close_fn = NULL,                               \
+        .uri_match_fn = NULL                            \
 }
 
 #define ESP_ERR_HTTPD_BASE              (0x8000)                    /*!< Starting number of HTTPD error codes */
@@ -108,6 +109,21 @@ typedef esp_err_t (*httpd_open_func_t)(httpd_handle_t hd, int sockfd);
  * @param[in] sockfd : session socket file descriptor
  */
 typedef void (*httpd_close_func_t)(httpd_handle_t hd, int sockfd);
+
+/**
+ * @brief  Function prototype for URI matching.
+ *
+ * @param[in] reference_uri   URI/template with respect to which the other URI is matched
+ * @param[in] uri_to_match    URI/template being matched to the reference URI/template
+ * @param[in] match_upto      For specifying the actual length of `uri_to_match` up to
+ *                            which the matching algorithm is to be applied (The maximum
+ *                            value is `strlen(uri_to_match)`, independent of the length
+ *                            of `reference_uri`)
+ * @return true on match
+ */
+typedef bool (*httpd_uri_match_func_t)(const char *reference_uri,
+                                       const char *uri_to_match,
+                                       size_t match_upto);
 
 /**
  * @brief   HTTP Server Configuration Structure
@@ -195,6 +211,24 @@ typedef struct httpd_config {
      * was closed by the network stack - that is, the file descriptor may not be valid anymore.
      */
     httpd_close_func_t close_fn;
+
+    /**
+     * URI matcher function.
+     *
+     * Called when searching for a matching URI:
+     *     1) whose request handler is to be executed right
+     *        after an HTTP request is successfully parsed
+     *     2) in order to prevent duplication while registering
+     *        a new URI handler using `httpd_register_uri_handler()`
+     *
+     * Available options are:
+     *     1) NULL : Internally do basic matching using `strncmp()`
+     *     2) `httpd_uri_match_wildcard()` : URI wildcard matcher
+     *
+     * Users can implement their own matching functions (See description
+     * of the `httpd_uri_match_func_t` function prototype)
+     */
+    httpd_uri_match_func_t uri_match_fn;
 } httpd_config_t;
 
 /**
@@ -743,6 +777,30 @@ esp_err_t httpd_req_get_url_query_str(httpd_req_t *r, char *buf, size_t buf_len)
  *  - ESP_ERR_HTTPD_RESULT_TRUNC : Value string truncated
  */
 esp_err_t httpd_query_key_value(const char *qry, const char *key, char *val, size_t val_size);
+
+/**
+ * @brief Test if a URI matches the given wildcard template.
+ *
+ * Template may end with "?" to make the previous character optional (typically a slash),
+ * "*" for a wildcard match, and "?*" to make the previous character optional, and if present,
+ * allow anything to follow.
+ *
+ * Example:
+ *   - * matches everything
+ *   - /foo/? matches /foo and /foo/
+ *   - /foo/\* (sans the backslash) matches /foo/ and /foo/bar, but not /foo or /fo
+ *   - /foo/?* or /foo/\*?  (sans the backslash) matches /foo/, /foo/bar, and also /foo, but not /foox or /fo
+ *
+ * The special characters "?" and "*" anywhere else in the template will be taken literally.
+ *
+ * @param[in] uri_template   URI template (pattern)
+ * @param[in] uri_to_match   URI to be matched
+ * @param[in] match_upto     how many characters of the URI buffer to test
+ *                          (there may be trailing query string etc.)
+ *
+ * @return true if a match was found
+ */
+bool httpd_uri_match_wildcard(const char *uri_template, const char *uri_to_match, size_t match_upto);
 
 /**
  * @brief   API to send a complete HTTP response.

--- a/components/esp_http_server/src/httpd_uri.c
+++ b/components/esp_http_server/src/httpd_uri.c
@@ -23,20 +23,112 @@
 
 static const char *TAG = "httpd_uri";
 
-static int httpd_find_uri_handler(struct httpd_data *hd,
-                                  const char* uri,
-                                  httpd_method_t method)
+static bool httpd_uri_match_simple(const char *uri1, const char *uri2, size_t len2)
 {
+    return strlen(uri1) == len2 &&          // First match lengths
+        (strncmp(uri1, uri2, len2) == 0);   // Then match actual URIs
+}
+
+bool httpd_uri_match_wildcard(const char *template, const char *uri, size_t len)
+{
+    const size_t tpl_len = strlen(template);
+    size_t exact_match_chars = tpl_len;
+
+    /* Check for trailing question mark and asterisk */
+    const char last = (const char) (tpl_len > 0 ? template[tpl_len - 1] : 0);
+    const char prevlast = (const char) (tpl_len > 1 ? template[tpl_len - 2] : 0);
+    const bool asterisk = last == '*' || (prevlast == '*' && last == '?');
+    const bool quest = last == '?' || (prevlast == '?' && last == '*');
+
+    /* Minimum template string length must be:
+     *      0 : if neither of '*' and '?' are present
+     *      1 : if only '*' is present
+     *      2 : if only '?' is present
+     *      3 : if both are present
+     *
+     * The expression (asterisk + quest*2) serves as a
+     * case wise generator of these length values
+     */
+
+    /* abort in cases such as "?" with no preceding character (invalid template) */
+    if (exact_match_chars < asterisk + quest*2) {
+        return false;
+    }
+
+    /* account for special characters and the optional character if "?" is used */
+    exact_match_chars -= asterisk + quest*2;
+
+    if (len < exact_match_chars) {
+        return false;
+    }
+
+    if (!quest) {
+        if (!asterisk && len != exact_match_chars) {
+            /* no special characters and different length - strncmp would return false */
+            return false;
+        }
+        /* asterisk allows arbitrary trailing characters, we ignore these using
+         * exact_match_chars as the length limit */
+        return (strncmp(template, uri, exact_match_chars) == 0);
+    } else {
+        /* question mark present */
+        if (len > exact_match_chars && template[exact_match_chars] != uri[exact_match_chars]) {
+            /* the optional character is present, but different */
+            return false;
+        }
+        if (strncmp(template, uri, exact_match_chars) != 0) {
+            /* the mandatory part differs */
+            return false;
+        }
+        /* Now we know the URI is longer than the required part of template,
+         * the mandatory part matches, and if the optional character is present, it is correct.
+         * Match is OK if we have asterisk, i.e. any trailing characters are OK, or if
+         * there are no characters beyond the optional character. */
+        return asterisk || len <= exact_match_chars + 1;
+    }
+}
+
+/* Find handler with matching URI and method, and set
+ * appropriate error code if URI or method not found */
+static httpd_uri_t* httpd_find_uri_handler(struct httpd_data *hd,
+                                           const char *uri, size_t uri_len,
+                                           httpd_method_t method,
+                                           httpd_err_resp_t *err)
+{
+    if (err) {
+        *err = HTTPD_404_NOT_FOUND;
+    }
+
     for (int i = 0; i < hd->config.max_uri_handlers; i++) {
-        if (hd->hd_calls[i]) {
-            ESP_LOGD(TAG, LOG_FMT("[%d] = %s"), i, hd->hd_calls[i]->uri);
-            if ((hd->hd_calls[i]->method == method) &&          // First match methods
-                (strcmp(hd->hd_calls[i]->uri, uri) == 0)) {     // Then match uri strings
-                return i;
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        ESP_LOGD(TAG, LOG_FMT("[%d] = %s"), i, hd->hd_calls[i]->uri);
+
+        /* Check if custom URI matching function is set,
+         * else use simple string compare */
+        if (hd->config.uri_match_fn ?
+            hd->config.uri_match_fn(hd->hd_calls[i]->uri, uri, uri_len) :
+            httpd_uri_match_simple(hd->hd_calls[i]->uri, uri, uri_len)) {
+            /* URIs match. Now check if method is supported */
+            if (hd->hd_calls[i]->method == method) {
+                /* Match found! */
+                if (err) {
+                    /* Unset any error that may
+                     * have been set earlier */
+                    *err = 0;
+                }
+                return hd->hd_calls[i];
+            }
+            /* URI found but method not allowed.
+             * If URI is found later then this
+             * error must be set to 0 */
+            if (err) {
+                *err = HTTPD_405_METHOD_NOT_ALLOWED;
             }
         }
     }
-    return -1;
+    return NULL;
 }
 
 esp_err_t httpd_register_uri_handler(httpd_handle_t handle,
@@ -48,15 +140,17 @@ esp_err_t httpd_register_uri_handler(httpd_handle_t handle,
 
     struct httpd_data *hd = (struct httpd_data *) handle;
 
-    /* Make sure another handler with same URI and method
-     * is not already registered
-     */
+    /* Make sure another handler with matching URI and method
+     * is not already registered. This will also catch cases
+     * when a registered URI wildcard pattern already accounts
+     * for the new URI being registered */
     if (httpd_find_uri_handler(handle, uri_handler->uri,
-                               uri_handler->method) != -1) {
+                               strlen(uri_handler->uri),
+                               uri_handler->method, NULL) != NULL) {
         ESP_LOGW(TAG, LOG_FMT("handler %s with method %d already registered"),
                  uri_handler->uri, uri_handler->method);
         return ESP_ERR_HTTPD_HANDLER_EXISTS;
-    }
+    } 
 
     for (int i = 0; i < hd->config.max_uri_handlers; i++) {
         if (hd->hd_calls[i] == NULL) {
@@ -95,16 +189,31 @@ esp_err_t httpd_unregister_uri_handler(httpd_handle_t handle,
     }
 
     struct httpd_data *hd = (struct httpd_data *) handle;
-    int i = httpd_find_uri_handler(hd, uri, method);
+    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
+        if (!hd->hd_calls[i]) {
+            break;
+        }
+        if ((hd->hd_calls[i]->method == method) &&       // First match methods
+            (strcmp(hd->hd_calls[i]->uri, uri) == 0)) {  // Then match URI string
+            ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, hd->hd_calls[i]->uri);
 
-    if (i != -1) {
-        ESP_LOGD(TAG, LOG_FMT("[%d] removing %s"), i, hd->hd_calls[i]->uri);
+            free((char*)hd->hd_calls[i]->uri);
+            free(hd->hd_calls[i]);
+            hd->hd_calls[i] = NULL;
 
-        free((char*)hd->hd_calls[i]->uri);
-        free(hd->hd_calls[i]);
-        hd->hd_calls[i] = NULL;
-        return ESP_OK;
-    }
+            /* Shift the remaining non null handlers in the array
+             * forward by 1 so that order of insertion is maintained */
+            for (i += 1; i < hd->config.max_uri_handlers; i++) {
+                if (!hd->hd_calls[i]) {
+                    break;
+                }
+                hd->hd_calls[i-1] = hd->hd_calls[i];
+            }
+            /* Nullify the following non null entry */
+            hd->hd_calls[i-1] = NULL;
+            return ESP_OK;
+        }
+    } 
     ESP_LOGW(TAG, LOG_FMT("handler %s with method %d not found"), uri, method);
     return ESP_ERR_NOT_FOUND;
 }
@@ -147,38 +256,6 @@ void httpd_unregister_all_uri_handlers(struct httpd_data *hd)
     }
 }
 
-/* Alternate implmentation of httpd_find_uri_handler()
- * which takes a uri_len field. This is useful when the URI
- * string contains extra parameters that are not to be included
- * while matching with the registered URI_handler strings
- */
-static httpd_uri_t* httpd_find_uri_handler2(httpd_err_resp_t *err,
-                                            struct httpd_data *hd,
-                                            const char *uri, size_t uri_len,
-                                            httpd_method_t method)
-{
-    *err = 0;
-    for (int i = 0; i < hd->config.max_uri_handlers; i++) {
-        if (hd->hd_calls[i]) {
-            ESP_LOGD(TAG, LOG_FMT("[%d] = %s"), i, hd->hd_calls[i]->uri);
-            if ((strlen(hd->hd_calls[i]->uri) == uri_len) &&            // First match uri length
-                (strncmp(hd->hd_calls[i]->uri, uri, uri_len) == 0))  {  // Then match uri strings
-                if (hd->hd_calls[i]->method == method)  {               // Finally match methods
-                    return hd->hd_calls[i];
-                }
-                /* URI found but method not allowed.
-                 * If URI IS found later then this
-                 * error is to be neglected */
-                *err = HTTPD_405_METHOD_NOT_ALLOWED;
-            }
-        }
-    }
-    if (*err == 0) {
-        *err = HTTPD_404_NOT_FOUND;
-    }
-    return NULL;
-}
-
 esp_err_t httpd_uri(struct httpd_data *hd)
 {
     httpd_uri_t            *uri = NULL;
@@ -191,10 +268,8 @@ esp_err_t httpd_uri(struct httpd_data *hd)
     ESP_LOGD(TAG, LOG_FMT("request for %s with type %d"), req->uri, req->method);
     /* URL parser result contains offset and length of path string */
     if (res->field_set & (1 << UF_PATH)) {
-        uri = httpd_find_uri_handler2(&err, hd,
-                                      req->uri + res->field_data[UF_PATH].off,
-                                      res->field_data[UF_PATH].len,
-                                      req->method);
+        uri = httpd_find_uri_handler(hd, req->uri + res->field_data[UF_PATH].off,
+                                     res->field_data[UF_PATH].len, req->method, &err);
     }
 
     /* If URI with method not found, respond with error code */

--- a/tools/esp_prov/proto/__init__.py
+++ b/tools/esp_prov/proto/__init__.py
@@ -39,6 +39,6 @@ wifi_constants_pb2 = _load_source("wifi_constants_pb2", idf_path + "/components/
 wifi_config_pb2    = _load_source("wifi_config_pb2",    idf_path + "/components/wifi_provisioning/python/wifi_config_pb2.py")
 wifi_scan_pb2      = _load_source("wifi_scan_pb2",      idf_path + "/components/wifi_provisioning/python/wifi_scan_pb2.py")
 
-# custom_provisioning component related python files generated from .proto files
-custom_config_pb2  = _load_source("custom_config_pb2",  idf_path +
-                                  "/examples/provisioning/custom_config/components/custom_provisioning/python/custom_config_pb2.py")
+# # custom_provisioning component related python files generated from .proto files
+# custom_config_pb2  = _load_source("custom_config_pb2",  idf_path +
+#                                   "/examples/provisioning/custom_config/components/custom_provisioning/python/custom_config_pb2.py")


### PR DESCRIPTION
I noticed that the http server component of the ESP-idf SDK allowed users to match URIs using wildcards, but the implementation in the ESP8266 SDK did not. I backported this functionality, using the same implementation as the ESP-idf SDK uses.