### PR TITLE
enable long calls in asm

### DIFF
--- a/components/freertos/port/esp8266/xtensa_vectors.S
+++ b/components/freertos/port/esp8266/xtensa_vectors.S
@@ -856,7 +856,9 @@ nmi_reentried:
     addi    a3,  a3,  1
     s32i    a3,  a2,  0
 
-    call0   wDev_ProcessFiq                         // call interrupt's C handler
+    .literal .LwDPF, wDev_ProcessFiq
+    l32r    a8, .LwDPF
+    callx0  a8                                      // call interrupt's C handler
 
     //Restore NMI level
     movi    a2,  _chip_nmi_cnt


### PR DESCRIPTION
When enabling `ESP8266_WIFI_DEBUG_LOG_ENABLE`, this linker error is raised:
```
.espressif/tools/xtensa-lx106-elf/esp-2020r3-49-gd5524c1-8.4.0/xtensa-lx106-elf/bin/../lib/gcc/xtensa-lx106-elf/8.4.0/../../../../xtensa-lx106-elf/bin/ld: esp-idf/freertos/libfreertos.a(xtensa_vectors.S.obj): in function `nmi_reentried':
ESP8266_RTOS_SDK/components/freertos/port/esp8266/xtensa_vectors.S:859:(.text+0x349): dangerous relocation: call0: call target out of range: wDev_ProcessFiq
collect2: error: ld returned 1 exit status
```

This pull request aims at fixing it.

I also tried this without success:
```diff
diff --git a/tools/cmake/toolchain-esp8266.cmake b/tools/cmake/toolchain-esp8266.cmake
index 565fbe9a..757b64fb 100644
--- a/tools/cmake/toolchain-esp8266.cmake
+++ b/tools/cmake/toolchain-esp8266.cmake
@@ -6,6 +6,7 @@ set(CMAKE_ASM_COMPILER xtensa-lx106-elf-gcc)
 
 set(CMAKE_C_FLAGS "-mlongcalls -Wno-frame-address" CACHE STRING "C Compiler Base Flags")
 set(CMAKE_CXX_FLAGS "-mlongcalls -Wno-frame-address" CACHE STRING "C++ Compiler Base Flags")
+set(CMAKE_ASM_FLAGS "-mlongcalls" CACHE STRING "ASM Compiler Base Flags")
 
 # Can be removed after gcc 5.2.0 support is removed (ref GCC_NOT_5_2_0)
 set(CMAKE_EXE_LINKER_FLAGS "-nostdlib -Wl,--gc-sections" CACHE STRING "Linker Base Flags")
```
But this change leads to this error:
```
.espressif/tools/xtensa-lx106-elf/esp-2020r3-49-gd5524c1-8.4.0/xtensa-lx106-elf/bin/../lib/gcc/xtensa-lx106-elf/8.4.0/../../../../xtensa-lx106-elf/bin/ld:esp8266.project.ld:58 cannot move location counter backwards (from 0000000040100021 to 0000000040100020)
collect2: error: ld returned 1 exit status
```
