### PR TITLE
pthread: fix link flags

### DIFF
--- a/components/pthread/CMakeLists.txt
+++ b/components/pthread/CMakeLists.txt
@@ -4,7 +4,7 @@ idf_component_register(SRCS "pthread.c"
                     INCLUDE_DIRS include)
 
 set(extra_link_flags "-u pthread_include_pthread_impl")
-list(APPEND extra_link_flags "-u pthread_include_pthread_cond_impl")
+list(APPEND extra_link_flags "-u pthread_include_pthread_cond_var_impl")
 list(APPEND extra_link_flags "-u pthread_include_pthread_local_storage_impl")
 
 if(CONFIG_FREERTOS_ENABLE_STATIC_TASK_CLEAN_UP)


### PR DESCRIPTION
This fixes building the idf::pthread component for C++. Previously in linking libstdc++ there were a few errors "undefined reference to pthread_cond_init", "undefined reference to pthread_cond_broadcast" and "undefined reference to pthread_cond_wait".

As suggested by herve-sg in #1083 one has to change the linker flags in CMakeLists.txt of the pthread component. After this change it compiles & links successfully.

As there was no pull request for this easy fix, I made one.

fixes #1083 