### PR TITLE
feat(ccache): Add ccache for unix building systems

### DIFF
--- a/tools/cmake/idf.cmake
+++ b/tools/cmake/idf.cmake
@@ -44,3 +44,10 @@ if(NOT __idf_env_set)
 
     set_property(GLOBAL PROPERTY __IDF_ENV_SET 1)
 endif()
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    # Support Unix Makefiles and Ninja
+    set(CMAKE_C_COMPILER_LAUNCHER   "ccache")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "ccache")
+endif()


### PR DESCRIPTION
Ccache is a compiler cache. It [speeds up recompilation](https://ccache.dev/performance.html) by caching previous compilations and detecting when the same compilation is being done again. Ccache is free software, released under the [GNU General Public License version 3](http://www.gnu.org/licenses/gpl.html) or later. See also the [license page](https://ccache.dev/license.html).

https://ccache.dev/

This patch are basically from [using-ccache-with-cmake](https://crascit.com/2016/04/09/using-ccache-with-cmake/). Can someone verify that OSX also works?

I tried on Linux, it works well.