### PR TITLE
Add option to favor DRAM allocation vs IRAM

### DIFF
--- a/components/heap/Kconfig
+++ b/components/heap/Kconfig
@@ -13,4 +13,12 @@ menu "Heap memory"
         help
             Enables heap tracing API.
 
+    config HEAP_PRIO_8BIT_RAM
+        bool "Prioritize allocation of 8-bit access capable RAM"
+        default n
+        depends on !HEAP_DISABLE_IRAM
+        help
+            Set DRAM region ahead of IRAM region during initialization, so that allocations
+            can be made against it first.
+
 endmenu


### PR DESCRIPTION
If `CONFIG_HEAP_DISABLE_IRAM` is disabled, IRAM is the first heap region set. 

https://github.com/espressif/ESP8266_RTOS_SDK/blob/d48c4c17068f584d47523bab0d4c94259724ba56/components/heap/port/esp8266/esp_heap_init.c#L37-L60

The allocator, therefore, sees the IRAM region first and allocates from it when given `MALLOC_CAP_32BIT`.

https://github.com/espressif/ESP8266_RTOS_SDK/blob/d48c4c17068f584d47523bab0d4c94259724ba56/components/heap/src/esp_heap_caps.c#L114-L123

This seems to incur a performance penalty given the needed unaligned access handling. This PR adds an option to set DRAM region ahead of IRAM during initialization