### PR TITLE
Fix warnings when LWIP asserts are disabled

### DIFF
--- a/components/lwip/port/esp8266/freertos/sys_arch.c
+++ b/components/lwip/port/esp8266/freertos/sys_arch.c
@@ -81,6 +81,7 @@ sys_mutex_lock(sys_mutex_t *pxMutex)
   BaseType_t ret = xSemaphoreTake(*pxMutex, portMAX_DELAY);
 
   LWIP_ASSERT("failed to take the mutex", ret == pdTRUE);
+  (void)ret;
 }
 
 /**
@@ -94,6 +95,7 @@ sys_mutex_unlock(sys_mutex_t *pxMutex)
   BaseType_t ret = xSemaphoreGive(*pxMutex);
 
   LWIP_ASSERT("failed to give the mutex", ret == pdTRUE);
+  (void)ret;
 }
 
 /**
@@ -133,6 +135,7 @@ sys_sem_new(sys_sem_t *sem, u8_t count)
   if (count == 1) {
       BaseType_t ret = xSemaphoreGive(*sem);
       LWIP_ASSERT("sys_sem_new: initial give failed", ret == pdTRUE);
+      (void)ret;
   }
 
   return ERR_OK;
@@ -150,6 +153,7 @@ sys_sem_signal(sys_sem_t *sem)
   /* queue full is OK, this is a signal only... */
   LWIP_ASSERT("sys_sem_signal: sane return value",
              (ret == pdTRUE) || (ret == errQUEUE_FULL));
+  (void)ret;
 }
 
 /*-----------------------------------------------------------------------------------*/
@@ -246,6 +250,7 @@ sys_mbox_post(sys_mbox_t *mbox, void *msg)
 {
   BaseType_t ret = xQueueSendToBack((*mbox)->os_mbox, &msg, portMAX_DELAY);
   LWIP_ASSERT("mbox post failed", ret == pdTRUE);
+  (void)ret;
 }
 
 /**
@@ -385,6 +390,8 @@ sys_mbox_free(sys_mbox_t *mbox)
   vQueueDelete((*mbox)->os_mbox);
   free(*mbox);
   *mbox = NULL;
+
+  (void)msgs_waiting;
 }
 
 /**


### PR DESCRIPTION
Porting the changes from this commit: https://github.com/espressif/esp-idf/commit/d6f4d99d937eda1a1a677ea1782852976262ca20#diff-a25942af0ed107ec1de90137df48f71213088c2d5b710c7dad00f8c6cb512901