### PR TITLE
Fix cmake extension warning

### DIFF
--- a/components/spi_flash/CMakeLists.txt
+++ b/components/spi_flash/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(srcs "src/partition"
+set(srcs "src/partition.c"
          "src/spi_flash_raw.c"
          "src/spi_flash.c")
 if(BOOTLOADER_BUILD)


### PR DESCRIPTION
Fixes the warning:

```
-- Configuring done
CMake Warning (dev) at ESP8266_RTOS_SDK/tools/cmake/component.cmake:437 (add_library):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:

    ESP8266_RTOS_SDK/components/spi_flash/src/partition.c
Call Stack (most recent call first):
  ESP8266_RTOS_SDK/components/spi_flash/CMakeLists.txt:11 (idf_component_register)
This warning is for project developers.  Use -Wno-dev to suppress it.

```