### PR TITLE
Fix for Cmake policy warning 'CMP0115' on components/spi_flash/CMakeLists.txt (GIT8266O-793)

### DIFF
--- a/components/spi_flash/CMakeLists.txt
+++ b/components/spi_flash/CMakeLists.txt
@@ -1,14 +1,14 @@
-set(srcs "src/partition"
-         "src/spi_flash_raw.c"
-         "src/spi_flash.c")
 if(BOOTLOADER_BUILD)
-    set(srcs "${srcs}" "port/port.c")
-    set(priv_requires "bootloader_support")
-else()
-    set(priv_requires "esp8266" "freertos" "bootloader_support")
-endif()
-
-idf_component_register(SRCS "${srcs}"
+   set(priv_requires "bootloader_support")
+   idf_component_register(SRCS "src/partition.c" "src/spi_flash_raw.c" "src/spi_flash.c" "port/port.c"
                        PRIV_REQUIRES "${priv_requires}"
                        INCLUDE_DIRS "include"
                        LDFRAGMENTS "linker.lf")
+
+else()
+    set(priv_requires "esp8266" "freertos" "bootloader_support")
+    idf_component_register(SRCS "src/partition.c" "src/spi_flash_raw.c" "src/spi_flash.c"
+                           PRIV_REQUIRES "${priv_requires}"
+                           INCLUDE_DIRS "include"
+                           LDFRAGMENTS "linker.lf")
+endif()


### PR DESCRIPTION
Explicit extensions for SRCS files when doing conditional checks on [components/spi_flash/CMakeLists.txt](https://github.com/espressif/ESP8266_RTOS_SDK/pull/1217/files#diff-4a3f76388ff9695797f574f7662b6b9556841a9f2549d94080409306863f28e5)

Refer to `cmake --help-policy CMP0115` for info.