### PR TITLE
bootloader: fix build with CONFIG_CONSOLE_UART_NONE

### DIFF
--- a/components/bootloader_support/src/bootloader_init.c
+++ b/components/bootloader_support/src/bootloader_init.c
@@ -568,8 +568,10 @@ void __assert_func(const char *file, int line, const char *func, const char *exp
 #  endif
 #endif
 
-#ifndef ESP8266_MODIFY_UART_BAUDRATE
-#  define ESP8266_MODIFY_UART_BAUDRATE 1
+#ifndef CONFIG_CONSOLE_UART_NONE
+#  ifndef ESP8266_MODIFY_UART_BAUDRATE
+#    define ESP8266_MODIFY_UART_BAUDRATE 1
+#  endif
 #endif
 
 extern int _bss_start;


### PR DESCRIPTION
Setting CONFIG_CONSOLE_UART_NONE would trigger the following error:
```
ESP8266_RTOS_SDK/components/bootloader_support/src/bootloader_init.c: In function 'uart_console_configure':
ESP8266_RTOS_SDK/components/bootloader_support/src/bootloader_init.c:628:80:
  error: 'CONFIG_ESP_CONSOLE_UART_BAUDRATE' undeclared (first use in this function); did you mean 'CONFIG_ESP_CONSOLE_UART_NUM'?
     uart_div_modify(CONFIG_ESP_CONSOLE_UART_NUM, BOOTLOADER_CONSOLE_CLK_FREQ / CONFIG_ESP_CONSOLE_UART_BAUDRATE);
                                                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                CONFIG_ESP_CONSOLE_UART_NUM
```

This is because `ESP8266_MODIFY_UART_BAUDRATE` is unconditionally defined, even when `CONFIG_CONSOLE_UART_NONE` is set.

This commit fixes this.