### PR TITLE
esp8266/ets_printf: Introduce __ets_vprintf_disable

### DIFF
--- a/components/esp8266/include/esp_libc.h
+++ b/components/esp8266/include/esp_libc.h
@@ -61,6 +61,20 @@ int ets_putc(int c);
   */
 int ets_vprintf(const char *fmt, va_list ap);
 
+/**
+ * libnet80211.a produces some debug output using ets_printf(), and continues
+ * to use this function well after bootup. If the serial port is used for other
+ * purposes than logging, it disrupts serial communication at arbitraty moments.
+ * The output looks like:
+ * I (5504) wifi:state: 0 -> 2 (b0)
+ * I (5545) wifi:state: 2 -> 3 (0)
+ * I (5551) wifi:state: 3 -> 5 (10)
+ * This flag is a quick stopgap solution. If set by the app, ets_vprintf() output
+ * is completely supressed.
+ * See https://github.com/espressif/ESP8266_RTOS_SDK/issues/1082
+ */
+extern int __ets_vprintf_disable;
+
 #ifndef os_printf
 #define os_printf   printf
 #endif

--- a/components/esp8266/source/ets_printf.c
+++ b/components/esp8266/source/ets_printf.c
@@ -176,8 +176,13 @@ static int ets_printf_int(val_attr_t * const attr, uint8_t hex)
     return 0;
 }
 
+int __ets_vprintf_disable = 0;
+
 int ets_vprintf(const char *fmt, va_list va)
 {
+    if (__ets_vprintf_disable)
+        return 0;
+
     for (; ;) {
         const char *ps = fmt;
         val_attr_t attr;


### PR DESCRIPTION
A quick solution to serial port pollution bug. The culprit is libnet80211.a, which uses ets_printf() long after the system bootup. Set the flag from within the application to nonzero value in order to completely suppress this output.

Signed-off-by: Pavel Fedin <pavel_fedin@mail.ru>

This patch is a quick solution to https://github.com/espressif/ESP8266_RTOS_SDK/issues/1082