### PR TITLE
fix(esp_https_ota): only do ota when http status code is 200

### DIFF
--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -64,6 +64,13 @@ esp_err_t esp_https_ota(const esp_http_client_config_t *config)
     }
     esp_http_client_fetch_headers(client);
 
+    int statusCode = esp_http_client_get_status_code(client);
+    if (statusCode != 200) {
+        ESP_LOGE(TAG, "Received incorrect HTTP status code: %d (expected: 200)", statusCode);
+        http_cleanup(client);
+        return ESP_FAIL;
+    }
+
     esp_ota_handle_t update_handle = 0;
     const esp_partition_t *update_partition = NULL;
     ESP_LOGI(TAG, "Starting OTA...");


### PR DESCRIPTION
A status code of 404 (Not Found) returned from the OTA server causes the esp8266 to continue to write to the partition until it encounters an error of "OTA image has invalid magic byte (expected 0xE9, saw 0xXX)". This is somewhat ridiculous. HTTP StatusCode should be the first thing that we should do to check its content is right or not, not the Magic after reading some body. If the status code isn't OK, we should just simply drop the body (not read anything).

As for the code of esp-idf, it should also be better that we first check if the code is HttpStatus_OK, then any others. Processing non-OK HTTP error codes is sometimes optional. They exist for providing more debugging information (except for Redirections. Or maybe not, some implementations give us on option automatically do the redirections for us, not everybody who uses it). 

https://github.com/espressif/esp-idf/blob/master/components/esp_https_ota/src/esp_https_ota.c#L93-L135
