### PR TITLE
Fix string to bytes conversion

### DIFF
--- a/components/esptool_py/esptool/esptool.py
+++ b/components/esptool_py/esptool/esptool.py
@@ -1287,6 +1287,9 @@ class BaseFirmwareImage(object):
     def save_segment(self, f, segment, checksum=None):
         """ Save the next segment to the image file, return next checksum value if provided """
         f.write(struct.pack('<II', segment.addr, len(segment.data)))
+        # Ensure segment.data is in bytes
+        if isinstance(segment.data, str):
+            segment.data = segment.data.encode('utf-8')  # Encode string to bytes
         f.write(segment.data)
         if checksum is not None:
             return ESPLoader.checksum(segment.data, checksum)


### PR DESCRIPTION
## Description

This pull request introduces a change to the `save_segment` method in `esptool.py`. The main modification ensures that the `segment.data` is properly encoded as bytes if it is provided as a string. This change addresses potential issues when writing segment data to the image file, ensuring compatibility and preventing runtime errors due to incorrect data types.

### Motivation

This enhancement is crucial as it maintains data integrity when saving segments, especially when segment data may inadvertently be in string format. It allows for more robust handling of input data types, ensuring that the writing process to the image file functions smoothly without requiring external type checks.

## Related

- Fixes
- Related pull requests: 
- Documentation link: 

## Testing

I tested the changes by creating a new virtual environment and running the `esptool` with various segment data types (both string and bytes). All tests confirmed that the `save_segment` method works correctly, successfully writing segment data to the image file without any type-related errors.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [/] All CI checks (GH Actions) pass.
- [/] Documentation is updated as needed.
- [/] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.