### PR TITLE
Include file fix, bash path fix, and fixed hardcoded make command (GIT8266O-890)

### DIFF
--- a/tools/cmake/kconfig.cmake
+++ b/tools/cmake/kconfig.cmake
@@ -49,7 +49,7 @@ function(__kconfig_init)
             CONFIGURE_COMMAND ""
             BINARY_DIR "kconfig_bin"
             BUILD_COMMAND rm -f ${src_path}/zconf.lex.c ${src_path}/zconf.hash.c
-            COMMAND make -f ${src_path}/Makefile mconf-idf
+            COMMAND $(MAKE) -f ${src_path}/Makefile mconf-idf
             BUILD_BYPRODUCTS ${MCONF}
             INSTALL_COMMAND ""
             EXCLUDE_FROM_ALL 1

--- a/tools/kconfig/Makefile
+++ b/tools/kconfig/Makefile
@@ -167,7 +167,7 @@ check-lxdialog  := $(SRCDIR)/lxdialog/check-lxdialog.sh
 CFLAGS += $(shell $(CONFIG_SHELL) $(check-lxdialog) -ccflags) \
                     -DLOCALE -MMD -MP
 
-CFLAGS += -I "." -I "${SRCDIR}"
+CFLAGS += -I "/usr/local/include" -I "." -I "${SRCDIR}"
 
 %.o: $(SRCDIR)/%.c
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@

--- a/tools/kconfig/lxdialog/check-lxdialog.sh
+++ b/tools/kconfig/lxdialog/check-lxdialog.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 # Check ncurses compatibility
 
 # What library to link

--- a/tools/kconfig/lxdialog/check-lxdialog.sh
+++ b/tools/kconfig/lxdialog/check-lxdialog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/local/bin/bash
 # Check ncurses compatibility
 
 # What library to link


### PR DESCRIPTION
Fixes necessary to use the SDK on FreeBSD-13.5 and later.