### PR TITLE
Pin version of setuptools to support pkg_resources API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This is a list of python packages needed for ESP-IDF. This file is used with pip.
 # Please see the Get Started section of the ESP-IDF Programming Guide for further information.
 #
-setuptools
+setuptools<81
 # The setuptools package is required to install source distributions and on some systems is not installed by default.
 # Please keep it as the first item of this list.
 #


### PR DESCRIPTION
## Description

The script tools/check_python_dependencies.py uses the pkg_resources API, which was deprecated in Python 3.12 and has been removed in setuptools version 81.

This makes the export.sh script unusable.

Updating requirements.txt to versions older than this fixes the problem.

## Related

This issue is https://github.com/espressif/ESP8266_RTOS_SDK/issues/1309

A more complicated pull request is available at https://github.com/espressif/ESP8266_RTOS_SDK/pull/1314
this fixes the problem by updating the API.

This pull request is provided as a simpler solution which can hopefully be approved and merged more quickly.

## Testing

Run install.sh and then source export.sh.  It now reports success.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [x ] All CI checks (GH Actions) pass.
- [x ] Documentation is updated as needed.
- [x ] Tests are updated or added as necessary.
- [x ] Code is well-commented, especially in complex areas.
- [x ] Git history is clean — commits are squashed to the minimum necessary.

