### PR TITLE
Make idf_tools install not reinstall tool already on PATH

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1038,6 +1038,11 @@ def action_install(args):
         assert tool_version is not None
         tool_obj.find_installed_versions()
         tool_spec = '{}@{}'.format(tool_name, tool_version)
+
+        if tool_version == tool_obj.version_in_path:
+            info('Skipping {} (already in PATH)'.format(tool_spec))
+            continue
+
         if tool_version in tool_obj.versions_installed:
             info('Skipping {} (already installed)'.format(tool_spec))
             continue


### PR DESCRIPTION
## Description

Make idf_tools.py not reinstall a duplicate copy of the same version of a tool which is already in the system PATH.

## Related

N/A

## Testing

In my case I pre-install the compiler in a docker image, but I still want to run install.sh to set up a python environment.  This fix avoids a large download.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x ] Documentation is updated as needed.
- [x ] Tests are updated or added as necessary.
- [x ] Code is well-commented, especially in complex areas.
- [x ] Git history is clean — commits are squashed to the minimum necessary.
