### PR TITLE
Update export.sh so it can be sourced by bash -u

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -21,7 +21,7 @@ function idf_export_main() {
         return 1
     fi
 
-    if [[ -z "${IDF_PATH}" ]]
+    if [[ -z "${IDF_PATH-}" ]]
     then
         # If using bash, try to guess IDF_PATH from script location
         if [[ -n "${BASH_SOURCE}" ]]


### PR DESCRIPTION

## Description

Robust shell scripts set the `-u` option to fail on use of undefined variables.

When such a script sources export.sh, it terminates.

This change updates export.sh to correctly check for an undefined variable.


## Related

N/A

## Testing

Run export.sh from a bash script with the -u option set, with and without the IDF_PATH environment variable set.
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ x] This PR does not introduce breaking changes.
- [ x] All CI checks (GH Actions) pass.
- [ x] Documentation is updated as needed.
- [ x] Tests are updated or added as necessary.
- [ x] Code is well-commented, especially in complex areas.
- [ x] Git history is clean — commits are squashed to the minimum necessary.
