### PR TITLE
Update i2s.h

### DIFF
--- a/components/esp8266/include/driver/i2s.h
+++ b/components/esp8266/include/driver/i2s.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "esp_err.h"
 
 #ifdef __cplusplus
@@ -51,11 +52,14 @@ typedef enum {
  * @brief I2S channel format type
  */
 typedef enum {
-    I2S_CHANNEL_FMT_RIGHT_LEFT = 0x00,
-    I2S_CHANNEL_FMT_ALL_RIGHT,
-    I2S_CHANNEL_FMT_ALL_LEFT,
-    I2S_CHANNEL_FMT_ONLY_RIGHT,
-    I2S_CHANNEL_FMT_ONLY_LEFT,
+    I2S_CHANNEL_FMT_RIGHT_LEFT = 0x00, //будет чередовать правый и левый канал счередованием внутри 32бит блока  "Пк" -16бит + "Лк"-16бит =32 бит dma блок 
+    // "Пк"-24бит =32 бит dma блок +"Лк"-24бит =32 бит dma блок
+    I2S_CHANNEL_FMT_ALL_RIGHT, //будет чередовать правый и левый канал  "Пк" -16бит + "Лк"-16бит =32 бит dma блок 
+     // "Пк"-24бит =32 бит dma блок +"Лк"-24бит =32 бит dma блок
+    I2S_CHANNEL_FMT_ALL_LEFT, //будет чередовать левый и правый канал  "Лк" -16бит + "Пк"-16бит =32 бит dma блок 
+     // "Лк"-24бит =32 бит dma блок +"Пк"-24бит =32 бит dma блок
+    I2S_CHANNEL_FMT_ONLY_RIGHT,// только правый канал при 16 бит запакует два 16 бит семпла в 32 бит блок dma, при 24 бит один сэмпл засунет в 32 бит  блок dma
+    I2S_CHANNEL_FMT_ONLY_LEFT,// только левый канал при 16 бит запакует два 16 бит семпла в 32 бит блок dma, при 24 бит один сэмпл засунет в 32 бит  блок dma
 } i2s_channel_fmt_t;
 
 /**
@@ -110,9 +114,17 @@ typedef struct {
 
 /**
  * @brief I2S pin enable for i2s_set_pin
+ *
+ * NOTE: fields are `int` (not `bool`) to support the `1/-1` sentinel pattern
+ * used by other SDK drivers (e.g. ir_tx.c uses `1` to enable a pin and `-1`
+ * to skip it). The i2s_set_pin implementation uses a truthy test (any nonzero
+ * value enables the pin), so all of the following work: 0/1, true/false,
+ * 1/-1, MY_FLAG_MACRO!=0. Changing to `bool` would break this pattern and
+ * is therefore avoided — fix #15 (truthy test instead of `== true`) is the
+ * correct and sufficient fix for the original bug.
  */
 typedef struct {
-    int bck_o_en;      /*!< BCK out pin*/
+    int bck_o_en;      /*!< BCK out pin (any nonzero = enable, 0 = skip)*/
     int ws_o_en;       /*!< WS out pin*/
     int bck_i_en;      /*!< BCK in pin*/
     int ws_i_en;       /*!< WS in pin*/
@@ -182,30 +194,6 @@ esp_err_t i2s_driver_uninstall(i2s_port_t i2s_num);
  */
 esp_err_t i2s_write(i2s_port_t i2s_num, const void *src, size_t size, size_t *bytes_written, TickType_t ticks_to_wait);
 
-/**
- * @brief Write data to I2S DMA transmit buffer while expanding the number of bits per sample. For example, expanding 16-bit PCM to 32-bit PCM.
- *
- * @note many ticks pass without space becoming available in the DMA
- *       transmit buffer, then the function will return (note that if the
- *       data is written to the DMA buffer in pieces, the overall operation
- *       may still take longer than this timeout.) Pass portMAX_DELAY for no
- *       timeout.
- *       Format of the data in source buffer is determined by the I2S
- *       configuration (see i2s_config_t).
- *
- * @param i2s_num             I2S_NUM_0
- * @param src                 Source address to write from
- * @param size                Size of data in bytes
- * @param src_bits            Source audio bit
- * @param aim_bits            Bit wanted, no more than 32, and must be greater than src_bits
- * @param[out] bytes_written  Number of bytes written, if timeout, the result will be less than the size passed in.
- * @param ticks_to_wait       TX buffer wait timeout in RTOS ticks. If this
- *
- * @return
- *     - ESP_OK              Success
- *     - ESP_ERR_INVALID_ARG Parameter error
- */
-esp_err_t i2s_write_expand(i2s_port_t i2s_num, const void *src, size_t size, size_t src_bits, size_t aim_bits, size_t *bytes_written, TickType_t ticks_to_wait);
 
 /**
  * @brief Read data from I2S DMA receive buffer


### PR DESCRIPTION
📌 Summary
This PR provides a comprehensive rewrite and bugfix of the ESP8266 I2S driver (i2s.c and i2s.h). It resolves critical issues where I2S fails to produce any data (silent capture) when compiled with -Os/-O2 optimization, alongside multiple stability, channel configuration, and API consistency fixes.

🔍 Root Cause of -Os/-O2 Failure
At -Os/-O2, GCC aggressively inlines i2s_param_config, i2s_set_rate, and i2s_reset_fifo into i2s_driver_install and i2s_set_clk. This causes the compiler to reorder peripheral register write-read sequences, breaking the strict hardware initialization sequence (reset → configure → enable).

Specifically, the read-modify-write operation on the SLC_CONF0 register (setting slc_mode) gets reordered relative to the DMA link start (rx_link.start = 1). The DMA starts in the wrong mode, causing I2S to silently drop all incoming data.

ℹ️ Note: Map file analysis confirms the functions are inlined (size drops to 0) and the i2s_driver_install footprint doubles at -Os.

🛠️ Key Fixes Included
1. Memory Barriers (I2S_MEMW)
Added Xtensa LX106 memw instruction barriers (__asm__ __volatile__("memw" ::: "memory")) between critical MMIO write sequences in i2s_param_config, i2s_set_rate, i2s_start, and i2s_driver_install. This forces both the compiler and the CPU to respect the strict ordering of peripheral register writes.

2. BBPLL Audio Clock Enable
Added rom_i2c_writeReg_Mask(0x67, 4, 4, 7, 7, 1) inside i2s_driver_install. Per TRM §10.2.1.2, I2S requires the BBPLL audio clock to be enabled to generate BCK/WS signals. Without this, BCK/WS stay LOW on certain boards, and i2s_read() returns 0 bytes (timeouts).

3. Float Precision in Rate Calculation
Replaced integer abs() with fabsf() and scaled_base_freq with FLT_MAX in the BCK/MCLK divider search loop inside i2s_set_rate(). The old code produced undefined behavior with floats and failed to find the correct dividers for specific sample rates.

4. Channel Configuration Fixes (N5, M2, M4)
Corrected channel_format to chan_mod/fifo_mod mapping for TX/RX. Previously, ONLY_LEFT (4) was truncated to 0 (dual mode) by the 2-bit RX field mask, causing RX to sample both slots while fifo_mod was single, resulting in all-zero data.
Ensured channel_format consistency during i2s_set_clk channel changes.
5. Concurrency and Stability Fixes
D1: i2s_set_clk now uses a 1-second timeout on mutex take instead of portMAX_DELAY, preventing system-wide deadlocks if a writer task is stuck.
R8: Guarded against double-uninstall in i2s_set_clk error paths.
#23: Added NULL check for xQueueCreate in i2s_driver_install.
U2: i2s_stop now correctly drains pending DMA descriptors before stopping interrupts.
#15: Fixed i2s_set_pin to use a truthy test instead of == true for pin enable flags, supporting the SDK's 1/-1 sentinel pattern used by other drivers.
6. API Cleanup
Removed the unimplemented i2s_write_expand function declaration from i2s.h to prevent linker errors or undefined behavior if called.

🧪 Testing
Hardware: INMP441 I2S MEMS microphone + ESP8266 (ESP-12F).
Configurations: Tested at 8/16/22/32/44.1/48 kHz, 16-bit and 24-bit, mono and stereo.
Optimization: Verified working at both -Og and -Os optimization levels.
Stability: 48kHz/24-bit/stereo streaming stable for 30+ minutes without drops or crashes.
Compatibility: Verified no regressions in standard TX/RX audio applications.